### PR TITLE
Fix admin guard execution and document API base URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,55 @@
-# opportunity
+# Classes monorepo
 
-## Project setup
+This repository hosts both the front-end (Vite + Vue 3) and back-end (Express)
+applications that power classes.jacobdanderson.net. The workspace is managed
+with npm workspaces; most commands can be run from the repository root by
+passing the `-w` flag to select the project.
 
-```
+## Installation
+
+```bash
 npm install
 ```
 
-### Compiles and hot-reloads for development
+## Local development
 
-```
-npm run serve
-```
+Run the front-end SSG app in dev mode:
 
-### Compiles and minifies for production
-
-```
-npm run build
+```bash
+npm run -w front-end dev
 ```
 
-### Lints and fixes files
+Run the Express API locally (loads environment variables from `.env`):
+
+```bash
+npm run -w back-end server
+```
+
+## API base URL configuration
+
+The front-end uses Axios via `src/api.ts`. By default requests are made against
+`/api`, which is proxied to the Express server in development. In production
+deployments you will usually want to point to the deployed API host instead.
+
+Set the following build-time environment variable when generating the static
+site to override the base URL:
 
 ```
-npm run lint
+VITE_API_BASE_URL=https://your-api-host.example.com
 ```
 
-### Customize configuration
+With this configuration the admin mail tool and other authenticated requests
+will target the correct server instead of the static host.
 
-See [Configuration Reference](https://cli.vuejs.org/config/).
+## Debugging on the server
+
+The Express server logs to standard output. Two helpful log sources are:
+
+* `Connected to MongoDB` messages emitted during startup.
+* 404 and unexpected error logs written by the handlers at the bottom of
+  `back-end/src/server.ts`. Every unmatched request is logged as
+  `404 Not Found: <METHOD> <path>`, and uncaught errors include the stack trace.
+
+When running the API under a process manager (for example `pm2`, `systemd`, or
+Docker) inspect that service's stdout/stderr logs to diagnose issues such as the
+admin mail endpoint returning `404` in production.

--- a/back-end/src/server.ts
+++ b/back-end/src/server.ts
@@ -2,7 +2,7 @@
 import { env, exit } from "node:process";
 import bodyParser from "body-parser";
 import cookieSession from "cookie-session";
-import express from "express";
+import express, { type NextFunction, type Request, type Response } from "express";
 import rateLimit from "express-rate-limit";
 import mongoose from "mongoose";
 
@@ -147,7 +147,17 @@ async function main() {
 		res.json({ adminID: s?.adminID ?? null, tutorID: s?.tutorID ?? null, userID: s?.userID ?? null });
 	});
 
-	const PORT = env.PORT || 3008;
+        app.use((req, res) => {
+                console.warn(`404 Not Found: ${req.method} ${req.originalUrl}`);
+                res.status(404).json({ message: "Not Found" });
+        });
+
+        app.use((err: unknown, req: Request, res: Response, _next: NextFunction) => {
+                console.error(`Unhandled error processing ${req.method} ${req.originalUrl}:`, err);
+                res.status(500).json({ message: "Internal Server Error" });
+        });
+
+        const PORT = env.PORT || 3008;
 	app.listen(PORT, () => console.log(`Server listening on port ${PORT}!`));
 }
 

--- a/front-end/src/api.ts
+++ b/front-end/src/api.ts
@@ -1,7 +1,15 @@
 // src/api.ts
 import axios from "axios";
 
+const baseURL = (() => {
+        const configured = import.meta.env.VITE_API_BASE_URL?.trim();
+        if (configured) {
+                return configured.replace(/\/?$/, "");
+        }
+        return "/api";
+})();
+
 export const api = axios.create({
-	baseURL: "/api",
-	withCredentials: true
+        baseURL,
+        withCredentials: true
 });

--- a/front-end/src/env.d.ts
+++ b/front-end/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+        readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+        readonly env: ImportMetaEnv;
+}

--- a/front-end/src/modules/admin-guard.ts
+++ b/front-end/src/modules/admin-guard.ts
@@ -4,7 +4,11 @@ import { api } from "@/api";
 import { useAppStore } from "@/stores/app";
 
 export const install: UserModule = ({ router }) => {
-	if (!import.meta.env.SS) return;
+        // This guard should only run in the browser. During SSG/SSR
+        // (when `import.meta.env.SSR` is true) the navigation guards are
+        // evaluated on the server where we do not have access to the
+        // cookie-backed session, so bail out early in that scenario.
+        if (import.meta.env.SSR) return;
 
 	router.beforeEach(async (to) => {
 		if (!to.meta.requiresAdmin) return;


### PR DESCRIPTION
## Summary
- ensure the admin navigation guard only bails on the server so client-side blocking works in production
- make the Axios client respect a `VITE_API_BASE_URL` override and add env typings
- document deployment notes and add explicit 404/error logging on the Express server for easier debugging

## Testing
- npm run -w front-end typecheck *(fails: `vue-tsc` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e096ffa4c0832ba6a8ed3562615f01