### PR TITLE
Fix admin guard gating and allow configurable API base URL

### DIFF
--- a/front-end/src/api.ts
+++ b/front-end/src/api.ts
@@ -1,7 +1,9 @@
 // src/api.ts
 import axios from "axios";
 
+const baseURL = import.meta.env.VITE_API_BASE_URL || "/api";
+
 export const api = axios.create({
-	baseURL: "/api",
-	withCredentials: true
+        baseURL,
+        withCredentials: true
 });

--- a/front-end/src/modules/admin-guard.ts
+++ b/front-end/src/modules/admin-guard.ts
@@ -4,7 +4,10 @@ import { api } from "@/api";
 import { useAppStore } from "@/stores/app";
 
 export const install: UserModule = ({ router }) => {
-	if (!import.meta.env.SS) return;
+        // Guards should only run in the browser. During SSG/SSR the
+        // navigation guard would run without access to the cookie-backed
+        // session, so bail out when rendering on the server.
+        if (import.meta.env.SSR) return;
 
 	router.beforeEach(async (to) => {
 		if (!to.meta.requiresAdmin) return;


### PR DESCRIPTION
## Summary
- ensure the admin navigation guard only installs on the client so it can see session cookies
- allow the Axios client to read the API base URL from `VITE_API_BASE_URL`, keeping `/api` as the default

## Testing
- `pnpm lint` *(fails: missing optional eslint dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e096ffa4c0832ba6a8ed3562615f01