### PR TITLE
Fix admin guard and expose API routes under /api

### DIFF
--- a/front-end/src/modules/admin-guard.ts
+++ b/front-end/src/modules/admin-guard.ts
@@ -4,7 +4,9 @@ import { api } from "@/api";
 import { useAppStore } from "@/stores/app";
 
 export const install: UserModule = ({ router }) => {
-	if (!import.meta.env.SS) return;
+        // This guard should only run in the client-side SPA.
+        // During SSG/SSR builds `router` isn't mounted, so bail early.
+        if (import.meta.env.SSR) return;
 
 	router.beforeEach(async (to) => {
 		if (!to.meta.requiresAdmin) return;


### PR DESCRIPTION
## Summary
- fix the admin navigation guard to only run on the client so production builds block unauthenticated users
- serve backend routes under both the root and /api prefixes and centralize auth cache headers so the frontend can reach the API in production

## Testing
- npm run -w back-end build *(fails: missing Express/Mongoose type definitions in the workspace)*
- npm run -w front-end typecheck *(fails: vue-tsc binary not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e096ffa4c0832ba6a8ed3562615f01