### PR TITLE
Refresh tutoring site content

### DIFF
--- a/front-end/src/components/TheFooter.vue
+++ b/front-end/src/components/TheFooter.vue
@@ -1,72 +1,90 @@
 <script lang="ts" setup></script>
 
 <template>
-	<footer class="text-center">
-		<div class="github">
-			<br />
-			<h2>Github</h2>
-			<br />
-			<nav class="footer_nav">
-				<ul class="semantic_list">
-					<li>
-						<a
-							href="https://github.com/Jacoba1100254352/classes.jacobdanderson.net"
-							target="_blank"
-							><img
-								id="githubIcon"
-								alt="github Icon"
-								src="../assets/Images/github-dark.09072337.svg"
-						/></a>
-					</li>
-				</ul>
-			</nav>
-		</div>
-
-		<div class="Logo_and_rights">
-			<br />
-			<h2>AudioT.info</h2>
-			<br />
-			<nav class="footer_nav">
-				<ul class="semantic_list">
-					<li>Provo, UT, USA</li>
-					<li>
-						©2021
-						<a
-							href="https://jacobdanderson.net"
-							style="text-decoration: none; color: inherit"
-							target="_blank"
-							>AudioT</a
-						>. All rights reserved.
-					</li>
-				</ul>
-			</nav>
-		</div>
-
-		<div class="parter">
-			<br />
-			<h2 />
-			<br />
-			<nav class="footer_nav">
-				<ul class="semantic_list">
-					<li>
-						<a
-							href=""
-							style="text-decoration: none; color: inherit"
-							target="_blank"
-						/>
-					</li>
-				</ul>
-				<br />
-				<p />
-			</nav>
-		</div>
-
-		<!--			<p v-if="error" class="error">{{ error }}</p> -->
-
-		<div class="ip pb-1">
-			<p id="ip" />
-		</div>
-	</footer>
+        <footer class="Footer text-center text-md-start py-4">
+                <div class="container">
+                        <div class="row gy-4">
+                                <div class="col-md-4">
+                                        <h2 class="h5">Jacob Anderson Tutoring</h2>
+                                        <p class="mb-0">
+                                                One-on-one instruction in programming, STEM, and Spanish for learners seeking confidence and clarity.
+                                        </p>
+                                </div>
+                                <div class="col-md-4">
+                                        <h3 class="h6">Stay connected</h3>
+                                        <ul class="list-unstyled mb-0">
+                                                <li>
+                                                        <a
+                                                                href="https://calendly.com/jacoba1100254352"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                Schedule a class
+                                                        </a>
+                                                </li>
+                                                <li>
+                                                        <a
+                                                                href="https://www.venmo.com/u/jacoba1100254352-classes"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                Venmo payments
+                                                        </a>
+                                                </li>
+                                        </ul>
+                                </div>
+                                <div class="col-md-4">
+                                        <h3 class="h6">More from Jacob</h3>
+                                        <ul class="list-unstyled mb-0">
+                                                <li>
+                                                        <a
+                                                                href="https://www.linkedin.com/in/jacoba1100254352/"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                LinkedIn
+                                                        </a>
+                                                </li>
+                                                <li>
+                                                        <a
+                                                                href="https://www.jacobdanderson.net"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                Portfolio site
+                                                        </a>
+                                                </li>
+                                                <li>
+                                                        <a
+                                                                href="https://github.com/Jacoba1100254352/classes.jacobdanderson.net"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                Project repository
+                                                        </a>
+                                                </li>
+                                        </ul>
+                                </div>
+                        </div>
+                        <div class="mt-4 text-center small text-muted">
+                                ©{{ new Date().getFullYear() }} Jacob Anderson. All rights reserved.
+                        </div>
+                </div>
+        </footer>
 </template>
 
-<style scoped></style>
+<style scoped>
+.Footer {
+        background-color: #0d3b66;
+        color: #f8f9fa;
+}
+
+.Footer a {
+        color: #f8f9fa;
+        text-decoration: none;
+}
+
+.Footer a:hover {
+        text-decoration: underline;
+}
+</style>

--- a/front-end/src/components/TheHeader.vue
+++ b/front-end/src/components/TheHeader.vue
@@ -3,107 +3,107 @@ import { storeToRefs } from "pinia";
 import { useAppStore } from "@/stores/app";
 
 const emit = defineEmits<{
-	(e: "loginClick"): void;
-	(e: "signupClick"): void;
+        (e: "loginClick"): void;
+        (e: "signupClick"): void;
 }>();
 
 const app = useAppStore();
 const { isLoggedIn, isAdmin } = storeToRefs(app);
 
 function logoutUser() {
-	app.logout();
+        app.logout();
 }
 </script>
 
 <template>
-	<header>
-		<nav
-			class="navbar navbar-expand-lg navbar-light"
-			style="background-color: #e3f2fd"
-		>
-			<div class="container-fluid">
-				<router-link
-					aria-current="page"
-					class="nav-item navbar-brand nav-link"
-					to="/"
-				>
-					Operation Opportunity
-				</router-link>
-				<button
-					aria-controls="navbarSupportedContent"
-					aria-expanded="false"
-					aria-label="Toggle navigation"
-					class="navbar-toggler"
-					data-bs-target="#navbarSupportedContent"
-					data-bs-toggle="collapse"
-					type="button"
-				>
-					<span class="navbar-toggler-icon" />
-				</button>
-				<div
-					id="navbarSupportedContent"
-					class="collapse navbar-collapse"
-				>
-					<ul class="nav navbar-nav mb-lg-0 mb-2 me-auto">
-						<li class="nav-item">
-							<router-link class="nav-link" to="/">
-								Home
-							</router-link>
-						</li>
-						<li class="nav-item">
-							<router-link class="nav-link" to="/signup">
-								Signup
-							</router-link>
-						</li>
-						<li class="nav-item">
-							<router-link class="nav-link" to="/supportus">
-								Support Us
-							</router-link>
-						</li>
-						<li class="nav-item">
-							<router-link class="nav-link" to="/about">
-								About
-							</router-link>
-						</li>
-						<li v-if="isLoggedIn" class="nav-item">
-							<router-link class="nav-link" to="/profile">
-								Profile
-							</router-link>
-						</li>
-						<li v-if="isAdmin" class="nav-item">
-							<router-link class="nav-link" to="/admin/mdmail">
-								Session Notes
-							</router-link>
-						</li>
-					</ul>
-					<!-- Logout Button -->
-					<button
-						v-if="isLoggedIn"
-						class="btn-outline-danger btn"
-						@click="logoutUser"
-					>
-						Logout
-					</button>
-					<!-- Login button -->
-					<button
-						v-else
-						class="btn-outline-success btn"
-						@click="emit('loginClick')"
-					>
-						Login
-					</button>
-					<!-- Signup button -->
-					<button
-						v-if="!isLoggedIn"
-						class="btn-outline-primary btn"
-						@click="emit('signupClick')"
-					>
-						Signup
-					</button>
-				</div>
-			</div>
-		</nav>
-	</header>
+        <header>
+                <nav
+                        class="navbar navbar-expand-lg navbar-light"
+                        style="background-color: #e3f2fd"
+                >
+                        <div class="container-fluid">
+                                <router-link
+                                        aria-current="page"
+                                        class="nav-item navbar-brand nav-link"
+                                        to="/"
+                                >
+                                        Jacob Anderson Tutoring
+                                </router-link>
+                                <button
+                                        aria-controls="navbarSupportedContent"
+                                        aria-expanded="false"
+                                        aria-label="Toggle navigation"
+                                        class="navbar-toggler"
+                                        data-bs-target="#navbarSupportedContent"
+                                        data-bs-toggle="collapse"
+                                        type="button"
+                                >
+                                        <span class="navbar-toggler-icon" />
+                                </button>
+                                <div
+                                        id="navbarSupportedContent"
+                                        class="collapse navbar-collapse"
+                                >
+                                        <ul class="nav navbar-nav mb-lg-0 mb-2 me-auto">
+                                                <li class="nav-item">
+                                                        <router-link class="nav-link" to="/">
+                                                                Home
+                                                        </router-link>
+                                                </li>
+                                                <li class="nav-item">
+                                                        <router-link class="nav-link" to="/supportus">
+                                                                Book a Class
+                                                        </router-link>
+                                                </li>
+                                                <li class="nav-item">
+                                                        <router-link class="nav-link" to="/about">
+                                                                About
+                                                        </router-link>
+                                                </li>
+                                                <li class="nav-item">
+                                                        <router-link class="nav-link" to="/signup">
+                                                                Create Account
+                                                        </router-link>
+                                                </li>
+                                                <li v-if="isLoggedIn" class="nav-item">
+                                                        <router-link class="nav-link" to="/profile">
+                                                                Profile
+                                                        </router-link>
+                                                </li>
+                                                <li v-if="isAdmin" class="nav-item">
+                                                        <router-link class="nav-link" to="/admin/mdmail">
+                                                                Session Notes
+                                                        </router-link>
+                                                </li>
+                                        </ul>
+                                        <!-- Logout Button -->
+                                        <button
+                                                v-if="isLoggedIn"
+                                                class="btn-outline-danger btn"
+                                                @click="logoutUser"
+                                        >
+                                                Logout
+                                        </button>
+                                        <!-- Login button -->
+                                        <button
+                                                v-else
+                                                class="btn-outline-success btn"
+                                                @click="emit('loginClick')"
+                                        >
+                                                Login
+                                        </button>
+                                        <!-- Signup button -->
+                                        <button
+                                                v-if="!isLoggedIn"
+                                                class="btn-outline-primary btn"
+                                                @click="emit('signupClick')"
+                                        >
+                                                Signup
+                                        </button>
+                                </div>
+                        </div>
+                </nav>
+        </header>
 </template>
 
 <style scoped></style>

--- a/front-end/src/pages/about.vue
+++ b/front-end/src/pages/about.vue
@@ -4,34 +4,63 @@ defineOptions({ name: "AboutPage" });
 </script>
 
 <template>
-	<!-------------
-  -   Section   -
-  -------------->
+        <section class="About py-5">
+                <div class="container text-start">
+                        <h1 class="display-6 fw-bold text-center">Meet Jacob</h1>
+                        <p class="lead mt-4">
+                                I'm an educator and engineer who loves helping students uncover the "why" behind every concept. At Juni
+                                Learning I guided learners around the world through coding, math, science, and language programs. As the
+                                company sunsets its services, I'm excited to continue supporting families directly with a flexible,
+                                personalized approach.
+                        </p>
 
-	<section class="About text-center">
-		<h1>About Us</h1>
-		<h2>Mission:</h2>
-		<img
-			alt="Smiling creepy college student"
-			class="m-5"
-			src="https://tenneyschool.com/wp-content/uploads/2016/11/Confident-Student.jpg"
-			width="40%"
-		/>
-		<p class="mt-3">Info</p>
-	</section>
+                        <div class="row g-4 align-items-start mt-4">
+                                <div class="col-lg-6">
+                                        <h2 class="h4">Teaching philosophy</h2>
+                                        <ul class="ps-3">
+                                                <li>Start with a conversation to understand each student's goals, strengths, and interests.</li>
+                                                <li>Build lessons that balance theory, hands-on practice, and real-world examples.</li>
+                                                <li>Celebrate progress and use mistakes as opportunities to deepen understanding.</li>
+                                                <li>Provide actionable feedback and resources after every session.</li>
+                                        </ul>
+                                </div>
+                                <div class="col-lg-6">
+                                        <h2 class="h4">Experience</h2>
+                                        <ul class="ps-3">
+                                                <li>Hundreds of hours tutoring Python, Java, C++, C, and full-stack web development.</li>
+                                                <li>Specialized workshops covering introductory AI and machine learning.</li>
+                                                <li>STEM mentoring in math and physics for middle school, high school, and college courses.</li>
+                                                <li>Spanish language instruction for conversational, academic, and AP-level needs.</li>
+                                        </ul>
+                                </div>
+                        </div>
+
+                        <div class="mt-4">
+                                <h2 class="h4">Beyond the classroom</h2>
+                                <p>
+                                        When I'm not teaching, you'll find me building software, exploring new educational tools, and investing in
+                                        community projects. I'm always eager to collaborate with families to design learning experiences that match
+                                        curiosity and pace.
+                                </p>
+                        </div>
+                </div>
+        </section>
 </template>
 
 <style scoped>
-p {
-	font-size: 15px;
-	margin: 0 10%;
+.About {
+        background-color: #ffffff;
+}
+
+ul li::marker {
+        color: #0d6efd;
 }
 </style>
 
 <route lang="json">
 {
-	"meta": {
-		"layout": "default"
-	}
+        "meta": {
+                "layout": "default"
+        }
 }
 </route>

--- a/front-end/src/pages/index.vue
+++ b/front-end/src/pages/index.vue
@@ -1,116 +1,171 @@
 <script lang="ts" setup>
-import { onMounted, ref } from "vue";
-import { api } from "@/api.ts";
-
 defineOptions({ name: "HomePage" });
 
-/* ---------------- state ---------------- */
-const quotePresent = ref(false);
-const quoteText = ref("");
-const quoteAuthor = ref("");
+const subjectGroups = [
+        {
+                title: "Programming & Computer Science",
+                description:
+                        "Project-driven lessons tailored to each student's goals across introductory and advanced coursework.",
+                items: [
+                        "Python fundamentals through advanced topics like data structures and algorithms",
+                        "Intro to Artificial Intelligence and Machine Learning",
+                        "Java and C++ for AP CSA, AP CS A, and university-level classes",
+                        "Modern web development with HTML, CSS, JavaScript, and TypeScript",
+                        "C for embedded systems, memory management, and low-level problem solving",
+                        "Creative coding in Scratch for younger learners"
+                ]
+        },
+        {
+                title: "STEM Foundations",
+                description: "Confidence-building support for challenging schoolwork and enrichment projects.",
+                items: [
+                        "Middle school through college-level mathematics",
+                        "Physics concepts, labs, and exam preparation"
+                ]
+        },
+        {
+                title: "Languages",
+                description: "Immersive conversational and academic Spanish tutoring for learners of all levels.",
+                items: ["Spanish language practice, grammar review, and cultural connections"]
+        }
+];
 
-/* ---------------- types ---------------- */
-// Set and given/managed by backend API (quoteProxy.ts)
-interface Quote {
-	_id: string;
-	content: string;
-	author: string;
-	tags: string[];
-	authorSlug: string;
-	length: number;
-	dateAdded: string; // ISO-8601 strings from the API
-	dateModified: string;
-}
-
-/* -------------- fetcher ---------------- */
-async function updateQuote() {
-	try {
-		// Optionally, choose only one quote:
-		// const res = await fetch("/api/quotes?tags=success&limit=1");
-		// const [q]  = await res.json();          // destructure first item
-		await api.get("/accounts/me");
-
-		const res = await fetch("/api/quotes?tags=success&limit=100");
-		if (!res.ok) {
-			console.error("Backend error", await res.text());
-			return;
-		}
-		const data = (await res.json()) as Quote[];
-
-		try {
-			if (data.length) {
-				quoteText.value = data[0].content;
-				quoteAuthor.value = data[0].author;
-				quotePresent.value = true;
-			}
-		} catch (e) {
-			console.warn("No quote retrieved:", data[0], e);
-			quotePresent.value = false;
-		}
-	} catch (err) {
-		console.error("Quote fetch failed:", err);
-	}
-}
-
-/* -------------- run once on client -------------- */
-onMounted(updateQuote);
+const classDetails = [
+        "50-minute live sessions with an optional 10-minute buffer to wrap up questions",
+        "$40 per class with transparent pricing and no long-term commitment",
+        "Flexible scheduling to accommodate busy student calendars",
+        "Personalized assignments and resources to reinforce each meeting"
+];
 </script>
 
 <template>
-	<!-------------
-  -   Section   -
-  -------------->
+        <section class="Home py-5">
+                <div class="container">
+                        <div class="row align-items-center g-5">
+                                <div class="col-lg-7 text-start">
+                                        <p class="eyebrow">Now offering one-on-one tutoring as Juni Learning transitions its programs.</p>
+                                        <h1 class="display-5 fw-bold">Build skills. Gain confidence. Enjoy learning.</h1>
+                                        <p class="lead mt-3">
+                                                I'm Jacob Anderson, a longtime Juni Learning instructor now teaching independently. I partner with
+                                                students to break down complex ideas, celebrate progress, and connect every lesson to real-world
+                                                interests.
+                                        </p>
+                                        <div class="cta-buttons d-flex flex-wrap gap-3 mt-4">
+                                                <a
+                                                        class="btn btn-primary btn-lg"
+                                                        href="https://calendly.com/jacoba1100254352"
+                                                        rel="noreferrer"
+                                                        target="_blank"
+                                                >
+                                                        Schedule a class
+                                                </a>
+                                                <a
+                                                        class="btn btn-outline-secondary btn-lg"
+                                                        href="https://www.venmo.com/u/jacoba1100254352-classes"
+                                                        rel="noreferrer"
+                                                        target="_blank"
+                                                >
+                                                        Venmo profile
+                                                </a>
+                                        </div>
+                                        <div class="mt-4">
+                                                <h2 class="h4">Class format</h2>
+                                                <ul class="list-unstyled mt-2">
+                                                        <li v-for="detail in classDetails" :key="detail" class="mb-2">
+                                                                <span aria-hidden="true" class="check-icon me-2">✓</span>{{ detail }}
+                                                        </li>
+                                                </ul>
+                                        </div>
+                                </div>
+                                <div class="col-lg-5 text-center">
+                                        <img
+                                                alt="Tutor working through code with a student"
+                                                class="img-fluid rounded shadow"
+                                                src="https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=900&q=80"
+                                        />
+                                </div>
+                        </div>
 
-	<section class="Home text-center">
-		<h1>Operation Opportunity</h1>
-		<div v-if="quotePresent" class="quote mt-3">
-			<q>{{ quoteText }}</q>
-			<br />
-			<p>
-				<span id="quote-author">- {{ quoteAuthor }}</span>
-			</p>
-		</div>
+                        <div class="subjects mt-5 text-start">
+                                <h2 class="h3">Subjects I teach</h2>
+                                <div class="row row-cols-1 row-cols-md-2 g-4 mt-1">
+                                        <div v-for="group in subjectGroups" :key="group.title" class="col">
+                                                <div class="card h-100 shadow-sm">
+                                                        <div class="card-body">
+                                                                <h3 class="card-title h5">{{ group.title }}</h3>
+                                                                <p class="card-text">{{ group.description }}</p>
+                                                                <ul class="ps-3">
+                                                                        <li v-for="item in group.items" :key="item">{{ item }}</li>
+                                                                </ul>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
 
-		<img
-			alt="Tutor helping college student"
-			class="m-5"
-			src="https://images.theconversation.com/files/268439/original/file-20190409-2921-1a4uike.jpg?ixlib=rb-1.1.0&q=30&auto=format&w=600&h=398&fit=crop&dpr=2"
-			width="30%"
-		/>
-		<h2>Welcome to ...!</h2>
-		<p class="mt-3">Info Here</p>
-	</section>
+                        <div class="mt-5 text-start">
+                                <h2 class="h4">Ready to get started?</h2>
+                                <p class="mb-3">
+                                        Book a session through Calendly, connect with me on LinkedIn, or explore my portfolio to learn more
+                                        about past projects and teaching philosophy.
+                                </p>
+                                <div class="d-flex flex-wrap gap-3">
+                                        <a
+                                                class="btn btn-outline-primary"
+                                                href="https://www.linkedin.com/in/jacoba1100254352/"
+                                                rel="noreferrer"
+                                                target="_blank"
+                                        >
+                                                Connect on LinkedIn
+                                        </a>
+                                        <a
+                                                class="btn btn-outline-primary"
+                                                href="https://www.jacobdanderson.net"
+                                                rel="noreferrer"
+                                                target="_blank"
+                                        >
+                                                Visit my portfolio
+                                        </a>
+                                </div>
+                        </div>
+                </div>
+        </section>
 </template>
 
 <style scoped>
-span {
-	font-family: cursive;
-	margin-left: 30px;
+.Home {
+        background: linear-gradient(180deg, #f7fbff 0%, #ffffff 100%);
 }
 
-.quote {
-	text-align: left;
-	width: 50%;
-	margin: 0 auto;
-	background-color: whitesmoke;
+.eyebrow {
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #0d6efd;
+        font-weight: 600;
 }
 
-q,
-#quote-author {
-	font-style: italic;
+.card-title {
+        color: #0d3b66;
 }
 
-@media only screen and (max-width: 960px) {
-	.quote {
-		width: 80%;
-	}
+.card-text {
+        color: #495057;
+}
+
+ul li::marker {
+        color: #0d6efd;
+}
+
+.check-icon {
+        color: #0d6efd;
+        font-weight: 700;
 }
 </style>
 
 <route lang="json">
 {
-	"meta": {
-		"layout": "default"
-	}
+        "meta": {
+                "layout": "default"
+        }
 }
 </route>

--- a/front-end/src/pages/supportus.vue
+++ b/front-end/src/pages/supportus.vue
@@ -3,29 +3,106 @@ defineOptions({ name: "SupportUsPage" });
 </script>
 
 <template>
-	<!-------------
-  -   Section   -
-  -------------->
+        <section class="Supportus py-5">
+                <div class="container text-start">
+                        <h1 class="display-6 fw-bold text-center">Book a class</h1>
+                        <p class="lead mt-3 text-center">
+                                Choose a time that works for you, then secure your spot with a quick Venmo payment. Sessions are $40 for
+                                50 minutes, with flexibility to continue for an additional 10 minutes when we need to wrap up a project or
+                                problem set.
+                        </p>
 
-	<section class="Supportus text-center">
-		<h1>Support Us</h1>
-		<img
-			alt="Donations"
-			class="m-5"
-			src="https://thumbor.forbes.com/thumbor/960x0/https%3A%2F%2Fblogs-images.forbes.com%2Ftheyec%2Ffiles%2F2014%2F06%2Fforbes115.jpg"
-			width="30%"
-		/>
-		<h2>Venmo</h2>
-		<p class="mt-3"></p>
-	</section>
+                        <div class="row g-5 mt-4">
+                                <div class="col-lg-7">
+                                        <h2 class="h4">Schedule with Calendly</h2>
+                                        <p>
+                                                Pick an available slot below. Calendly will automatically send the meeting link and calendar invite. If
+                                                you don't see a time that works, reach out and we'll coordinate something custom.
+                                        </p>
+                                        <div class="calendly-container mt-3">
+                                                <iframe
+                                                        allowtransparency="true"
+                                                        frameborder="0"
+                                                        height="680"
+                                                        scrolling="no"
+                                                        src="https://calendly.com/jacoba1100254352?hide_event_type_details=1&hide_gdpr_banner=1"
+                                                        title="Schedule a tutoring session"
+                                                        width="100%"
+                                                />
+                                        </div>
+                                        <p class="mt-3">
+                                                Prefer a separate window? <a href="https://calendly.com/jacoba1100254352" target="_blank" rel="noreferrer">Open Calendly in a new tab</a>.
+                                        </p>
+                                </div>
+                                <div class="col-lg-5">
+                                        <h2 class="h4">Secure payment</h2>
+                                        <p>
+                                                Pay after scheduling using Venmo. Please include the student's name and session date in the note so I can
+                                                confirm your booking quickly.
+                                        </p>
+                                        <div class="card shadow-sm">
+                                                <div class="card-body">
+                                                        <h3 class="card-title h5">Venmo</h3>
+                                                        <p class="card-text">Send payments to <strong>@jacoba1100254352-classes</strong>.</p>
+                                                        <a
+                                                                class="btn btn-outline-secondary"
+                                                                href="https://www.venmo.com/u/jacoba1100254352-classes"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                Open Venmo profile
+                                                        </a>
+                                                </div>
+                                        </div>
+
+                                        <div class="mt-4">
+                                                <h2 class="h5">Need help?</h2>
+                                                <p>
+                                                        Email me through LinkedIn or my website if you have questions about courses, scheduling, or group
+                                                        sessions. I'm happy to tailor a plan for families or small teams.
+                                                </p>
+                                                <div class="d-flex flex-wrap gap-3">
+                                                        <a
+                                                                class="btn btn-outline-primary"
+                                                                href="https://www.linkedin.com/in/jacoba1100254352/"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                Message on LinkedIn
+                                                        </a>
+                                                        <a
+                                                                class="btn btn-outline-primary"
+                                                                href="https://www.jacobdanderson.net"
+                                                                rel="noreferrer"
+                                                                target="_blank"
+                                                        >
+                                                                Visit my website
+                                                        </a>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </section>
 </template>
 
-<style scoped></style>
+<style scoped>
+.Supportus {
+        background-color: #f8f9fa;
+}
+
+.calendly-container {
+        border-radius: 0.75rem;
+        overflow: hidden;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+        background: #ffffff;
+}
+</style>
 
 <route lang="json">
 {
-	"meta": {
-		"layout": "default"
-	}
+        "meta": {
+                "layout": "default"
+        }
 }
 </route>


### PR DESCRIPTION
## Summary
- rewrite the home page with updated tutoring offerings, pricing, and calls to action for Calendly, Venmo, LinkedIn, and the portfolio site
- expand the about page with teaching philosophy and experience details tailored to independent tutoring
- add a booking-focused page with embedded Calendly scheduling, Venmo payment guidance, and contact links, plus refresh the global header and footer branding

## Testing
- `npm run -w front-end build` *(fails: vite-ssg command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43b929204832b8856568a9397757a