### PR TITLE
Serve branded static 404 pages

### DIFF
--- a/front-end/scripts/normalize-static-routes.mjs
+++ b/front-end/scripts/normalize-static-routes.mjs
@@ -4,31 +4,80 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const distDir = path.resolve(__dirname, "../dist");
+const publicDir = path.resolve(__dirname, "../public");
 
-export async function normalizeStaticRoutes(targetDistDir = distDir) {
-	const entries = await fs.readdir(targetDistDir, { withFileTypes: true });
+async function collectPublicDirectoryNames() {
+	const entries = await fs.readdir(publicDir, { withFileTypes: true });
+	return new Set(
+		entries.filter(entry => entry.isDirectory()).map(entry => entry.name)
+	);
+}
+
+async function collectHtmlFiles(
+	directory,
+	ignoredRootDirectories,
+	relativeDirectory = ""
+) {
+	const entries = await fs.readdir(directory, { withFileTypes: true });
+	const htmlFiles = [];
 
 	for (const entry of entries) {
-		if (!entry.isFile() || !entry.name.endsWith(".html")) {
+		const relativePath = path.join(relativeDirectory, entry.name);
+		if (entry.isDirectory()) {
+			if (
+				relativeDirectory === "" &&
+				ignoredRootDirectories.has(entry.name)
+			) {
+				continue;
+			}
+			htmlFiles.push(
+				...(await collectHtmlFiles(
+					path.join(directory, entry.name),
+					ignoredRootDirectories,
+					relativePath
+				))
+			);
+		} else if (entry.isFile() && entry.name.endsWith(".html")) {
+			htmlFiles.push(relativePath);
+		}
+	}
+
+	return htmlFiles;
+}
+
+export async function normalizeStaticRoutes(targetDistDir = distDir) {
+	const ignoredRootDirectories = await collectPublicDirectoryNames();
+	ignoredRootDirectories.add(".vite");
+	ignoredRootDirectories.add("assets");
+	const htmlFiles = await collectHtmlFiles(
+		targetDistDir,
+		ignoredRootDirectories
+	);
+
+	for (const relativeHtmlPath of htmlFiles) {
+		const fileName = path.basename(relativeHtmlPath);
+		if (fileName === "index.html" || relativeHtmlPath === "404.html") {
 			continue;
 		}
 
-		const routeName = entry.name.slice(0, -".html".length);
-		if (routeName === "index") {
-			continue;
-		}
-
-		const routeDirectory = path.join(targetDistDir, routeName);
+		const routePath = relativeHtmlPath.slice(0, -".html".length);
+		const routeDirectory = path.join(targetDistDir, routePath);
 		const targetIndexPath = path.join(routeDirectory, "index.html");
 
 		await fs.mkdir(routeDirectory, { recursive: true });
-		await fs.copyFile(path.join(targetDistDir, entry.name), targetIndexPath);
+		await fs.copyFile(
+			path.join(targetDistDir, relativeHtmlPath),
+			targetIndexPath
+		);
 		console.log(
 			`[normalize-static-routes] wrote ${path.relative(targetDistDir, targetIndexPath)}`
 		);
 	}
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
 	await normalizeStaticRoutes();
 }

--- a/front-end/scripts/sitemap.mts
+++ b/front-end/scripts/sitemap.mts
@@ -1,6 +1,7 @@
 export const SITE_URL = "https://classes.jacobdanderson.net";
 
 export const SITEMAP_EXCLUDED_ROUTES = [
+	"/404",
 	"/README",
 	"/admin",
 	"/admin/mdmail",

--- a/front-end/scripts/static-route-policy.mts
+++ b/front-end/scripts/static-route-policy.mts
@@ -1,0 +1,42 @@
+export const FRIENDLY_NOT_FOUND_ROUTE = "/404";
+export const FRIENDLY_NOT_FOUND_TITLE = "Page not found | Classes with Jacob";
+
+const titlePattern = /<title\b[^>]*>[\s\S]*?<\/title>/iu;
+const robotsMetaPattern = /<meta\b[^>]*\bname=["']robots["'][^>]*>/iu;
+
+function replaceOrInsertHeadElement(
+	html: string,
+	pattern: RegExp,
+	replacement: string
+) {
+	if (pattern.test(html)) return html.replace(pattern, replacement);
+
+	return html.replace(/<\/head>/iu, `${replacement}</head>`);
+}
+
+export function includedStaticRoutes(paths: string[]) {
+	const staticPaths = paths.filter(
+		path => !path.includes(":") && !path.includes("*")
+	);
+
+	return [...new Set([...staticPaths, FRIENDLY_NOT_FOUND_ROUTE])];
+}
+
+export function renderFriendlyNotFoundHead(
+	route: string,
+	renderedHTML: string
+) {
+	if (route !== FRIENDLY_NOT_FOUND_ROUTE) return renderedHTML;
+
+	const withTitle = replaceOrInsertHeadElement(
+		renderedHTML,
+		titlePattern,
+		`<title>${FRIENDLY_NOT_FOUND_TITLE}</title>`
+	);
+
+	return replaceOrInsertHeadElement(
+		withTitle,
+		robotsMetaPattern,
+		'<meta content="noindex,nofollow" name="robots">'
+	);
+}

--- a/front-end/src/pages/[...all].vue
+++ b/front-end/src/pages/[...all].vue
@@ -2,7 +2,13 @@
 const router = useRouter();
 
 useHead({
-	title: "Page not found | Classes with Jacob"
+	title: "Page not found | Classes with Jacob",
+	meta: [
+		{
+			name: "robots",
+			content: "noindex,nofollow"
+		}
+	]
 });
 
 function goBack() {

--- a/front-end/test/static-routes.spec.test.ts
+++ b/front-end/test/static-routes.spec.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	stat,
+	writeFile
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,24 +15,33 @@ import {
 	generateProductionSitemap,
 	sitemapOptions
 } from "../scripts/sitemap.mts";
+import {
+	FRIENDLY_NOT_FOUND_ROUTE,
+	FRIENDLY_NOT_FOUND_TITLE,
+	includedStaticRoutes,
+	renderFriendlyNotFoundHead
+} from "../scripts/static-route-policy.mts";
 
 const tempDirs: string[] = [];
+const frontEndRoot = process.cwd();
+const repositoryRoot = join(frontEndRoot, "..");
 
 describe("static route normalization", () => {
 	afterEach(async () => {
 		await Promise.all(
-			tempDirs.splice(0).map(tempDir =>
-				rm(tempDir, { recursive: true, force: true })
-			)
+			tempDirs
+				.splice(0)
+				.map(tempDir => rm(tempDir, { recursive: true, force: true }))
 		);
 	});
 
 	it("creates nested index files for clean static URLs", async () => {
 		const tempDir = await mkdtemp(join(tmpdir(), "classes-routes-"));
 		tempDirs.push(tempDir);
-		const { normalizeStaticRoutes } = await import("../scripts/normalize-static-routes.mjs") as {
-			normalizeStaticRoutes: (targetDistDir: string) => Promise<void>;
-		};
+		const { normalizeStaticRoutes } =
+			(await import("../scripts/normalize-static-routes.mjs")) as {
+				normalizeStaticRoutes: (targetDistDir: string) => Promise<void>;
+			};
 
 		await writeFile(join(tempDir, "index.html"), "<main>Home</main>");
 		await writeFile(
@@ -33,14 +49,106 @@ describe("static route normalization", () => {
 			"<main>Course Resource</main>"
 		);
 		await writeFile(join(tempDir, "about.html"), "<main>About</main>");
+		await writeFile(
+			join(tempDir, "404.html"),
+			"<main>Page not found</main>"
+		);
+		await mkdir(join(tempDir, "admin"), { recursive: true });
+		await writeFile(
+			join(tempDir, "admin", "student-management.html"),
+			"<main>Student management</main>"
+		);
+		await mkdir(join(tempDir, "course-assets"), { recursive: true });
+		await writeFile(
+			join(tempDir, "course-assets", "example.html"),
+			"<main>Static course asset</main>"
+		);
 
 		await normalizeStaticRoutes(tempDir);
+		await normalizeStaticRoutes(tempDir);
 
-		await expect(readFile(join(tempDir, "course-resource", "index.html"), "utf8"))
-			.resolves.toBe("<main>Course Resource</main>");
-		await expect(readFile(join(tempDir, "about", "index.html"), "utf8"))
-			.resolves.toBe("<main>About</main>");
-		await expect(stat(join(tempDir, "index", "index.html"))).rejects.toThrow();
+		await expect(
+			readFile(join(tempDir, "course-resource", "index.html"), "utf8")
+		).resolves.toBe("<main>Course Resource</main>");
+		await expect(
+			readFile(join(tempDir, "about", "index.html"), "utf8")
+		).resolves.toBe("<main>About</main>");
+		await expect(readFile(join(tempDir, "404.html"), "utf8")).resolves.toBe(
+			"<main>Page not found</main>"
+		);
+		await expect(
+			readFile(
+				join(tempDir, "admin", "student-management", "index.html"),
+				"utf8"
+			)
+		).resolves.toBe("<main>Student management</main>");
+		await expect(
+			stat(join(tempDir, "index", "index.html"))
+		).rejects.toThrow();
+		await expect(
+			stat(join(tempDir, "404", "index.html"))
+		).rejects.toThrow();
+		await expect(
+			stat(
+				join(
+					tempDir,
+					"admin",
+					"student-management",
+					"index",
+					"index.html"
+				)
+			)
+		).rejects.toThrow();
+		await expect(
+			stat(join(tempDir, "course-assets", "example", "index.html"))
+		).rejects.toThrow();
+	});
+
+	it("renders concrete routes plus the friendly not-found artifact", () => {
+		expect(
+			includedStaticRoutes([
+				"/",
+				"/courses",
+				"/courses",
+				"/:all(.*)*",
+				"/courses/:courseID"
+			])
+		).toEqual(["/", "/courses", FRIENDLY_NOT_FOUND_ROUTE]);
+	});
+
+	it("writes a noindex title and robots policy into the rendered 404 document", () => {
+		const document = [
+			"<!doctype html><html><head>",
+			"<title>Classes</title>",
+			'<meta content="index,follow" name="robots">',
+			"</head><body>Page not found</body></html>"
+		].join("");
+		const rendered404 = renderFriendlyNotFoundHead(
+			FRIENDLY_NOT_FOUND_ROUTE,
+			document
+		);
+
+		expect(rendered404).toContain(
+			`<title>${FRIENDLY_NOT_FOUND_TITLE}</title>`
+		);
+		expect(rendered404).toContain(
+			'<meta content="noindex,nofollow" name="robots">'
+		);
+		expect(rendered404).not.toContain("index,follow");
+		expect(renderFriendlyNotFoundHead("/courses", document)).toBe(document);
+	});
+
+	it("keeps the friendly 404 private from indexing and serves it through Netlify", async () => {
+		const [notFoundPage, netlifyConfig] = await Promise.all([
+			readFile(join(frontEndRoot, "src/pages/[...all].vue"), "utf8"),
+			readFile(join(repositoryRoot, "netlify.toml"), "utf8")
+		]);
+
+		expect(notFoundPage).toContain('name: "robots"');
+		expect(notFoundPage).toContain('content: "noindex,nofollow"');
+		expect(netlifyConfig.trimEnd()).toMatch(
+			/\[\[redirects\]\]\nfrom = "\/\*"\nto = "\/404[.]html"\nstatus = 404\nforce = false$/u
+		);
 	});
 
 	it("configures the production sitemap without localhost or private routes", () => {
@@ -56,6 +164,7 @@ describe("static route normalization", () => {
 		expect(options.exclude).toEqual(SITEMAP_EXCLUDED_ROUTES);
 		expect(options.exclude).toEqual(
 			expect.arrayContaining([
+				"/404",
 				"/admin",
 				"/admin/mdmail",
 				"/admin/people",

--- a/front-end/vite.config.mts
+++ b/front-end/vite.config.mts
@@ -13,6 +13,10 @@ import generateSitemap from "vite-ssg-sitemap";
 import { VueRouterAutoImports } from "vue-router/unplugin";
 import VueRouter from "vue-router/vite";
 import { generateProductionSitemap } from "./scripts/sitemap.mts";
+import {
+	includedStaticRoutes,
+	renderFriendlyNotFoundHead
+} from "./scripts/static-route-policy.mts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pythonIdePreloadChunkRE = /(?:^|\/)python-ide-runtime-[^/]+\.js$/;
@@ -85,6 +89,8 @@ export default defineConfig(({ command }) => ({
 	ssgOptions: {
 		script: "defer",
 		formatting: "minify",
+		includedRoutes: includedStaticRoutes,
+		onPageRendered: renderFriendlyNotFoundHead,
 		beastiesOptions: {
 			reduceInlineStyles: false
 		},
@@ -125,8 +131,8 @@ export default defineConfig(({ command }) => ({
 		proxy: {
 			"/api": {
 				target:
-					process.env.VITE_API_PROXY_TARGET
-					|| "http://localhost:3008",
+					process.env.VITE_API_PROXY_TARGET ||
+					"http://localhost:3008",
 				changeOrigin: true,
 				rewrite: p => p.replace(/^\/api/, "") // strip /api
 			}

--- a/netlify.toml
+++ b/netlify.toml
@@ -159,3 +159,9 @@ for = "/site.webmanifest"
 
 [headers.values]
 Content-Type = "application/manifest+json"
+
+[[redirects]]
+from = "/*"
+to = "/404.html"
+status = 404
+force = false


### PR DESCRIPTION
## Scope
- Render a dedicated noindex 404 artifact through the existing branded page.
- Normalize nested static routes recursively without copying public asset HTML.
- Make Netlify return the branded document with a true 404 while preserving the blocked API boundary.
- Exclude the 404 route from the sitemap.

## Local validation
- npm 12 root and standalone-backend clean installs completed with zero audit findings.
- Registry signatures and dependency trees passed.
- Lint and typecheck passed.
- Focused static-route tests passed (5/5).
- Bounded core front-end tests passed (1,037/1,037).
- Build artifact structure and branded noindex document were inspected during review.

Remaining heavy gates are intentionally delegated to PR CI because unrelated local work kept the repository load guard above its safe threshold.