### PR TITLE
Normalize formatter width and line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,4 +7,4 @@ tab_width = 4
 indent_size = 4
 indent_style = tab
 insert_final_newline = false
-max_line_length = 120
+max_line_length = 80

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 .gitattributes text eol=lf
+.editorconfig text eol=lf
 .node-version text eol=lf
 .nvmrc text eol=lf
+.prettierrc text eol=lf
 *.css text eol=lf
 *.conf text eol=lf
 *.conf.example text eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,11 @@
 {
 	"useTabs": true,
 	"tabWidth": 4,
+	"printWidth": 80,
 	"singleQuote": false,
 	"semi": true,
 	"trailingComma": "none",
 	"bracketSpacing": true,
-	"arrowParens": "avoid"
+	"arrowParens": "avoid",
+	"endOfLine": "lf"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - `npm run lint` (or `lint-fix`) runs the shared ESLint configuration across both workspaces; pre-commit hooks run `lint-staged` automatically.
 
 ## Coding Style & Naming Conventions
-- ESLint extends `@antfu/eslint-config` and enforces Prettier with tab indentation, double quotes, semicolons, 120-character lines, and LF endings. Run `npm run lint-fix` before pushing.
+- ESLint extends `@antfu/eslint-config` and enforces Prettier with tab indentation, double quotes, semicolons, 80-character lines, and LF endings. Run `npm run lint-fix` before pushing.
 - Vue single-file components use PascalCase filenames (`TheHeader.vue`), composables use the `useFeature` pattern, and Pinia stores live in `src/stores/`.
 - TypeScript modules should export camelCase functions and PascalCase classes/types. Keep front-end route files lowercase to match the generated router.
 - Prefer descriptive directory names (`controllers/common/`, `controllers/users/`) and colocate feature-specific assets alongside their modules.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,13 +6,18 @@ export default antfu(
 		root: true,
 		env: { browser: true, node: true, es2021: true },
 		unocss: true,
-		stylistic: { indent: "tab", quotes: "double", semi: true, linebreak: "unix" },
+		stylistic: {
+			indent: "tab",
+			quotes: "double",
+			semi: true,
+			linebreak: "unix"
+		},
 		formatters: {
 			prettier: {
 				tabWidth: 4,
 				useTabs: true,
 				trailingComma: "none",
-				printWidth: 120,
+				printWidth: 80,
 				endOfLine: "lf"
 			}
 		},


### PR DESCRIPTION
## Summary

- align EditorConfig, Prettier, and ESLint on the repository’s effective 80-column formatter width
- make Prettier’s LF behavior explicit
- pin the extensionless formatter configuration files to LF in Git attributes
- update the contributor guidance to match the enforced formatter

## Root cause

The primary lint paths and existing source layout use 80 columns, while EditorConfig, the ESLint formatter options, and contributor guidance declared 120 columns. Prettier also relied on implicit width and line-ending defaults, and the two extensionless configuration files were not covered by Git attributes. Linked worktrees could therefore apply conflicting formatting and line endings.

## Impact

Editors, Prettier, ESLint, and Git now agree on 80-column formatting and LF endings without reformatting application source or changing dependencies.

## Validation

- Node 24.18.0 and npm 12.0.1
- npm run lint
- npm run typecheck
- npm run test:native-deployment (6 tests)
- targeted Prettier configuration resolution, format check, and debug check
- targeted ESLint fix-dry-run verified an 80-column wrap with no diagnostics
- Git attribute LF checks for every changed configuration file
- git diff --check