### PR TITLE
Harden project payload and install-script handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,14 @@ jobs:
                   npm -v
                   npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
+
+            - name: Verify standalone backend install policy
+              run: node --test test/standalone-backend-install-policy.test.mjs
 
             - name: Install backend deps with backend lockfile
               working-directory: back-end
-              run: npm ci --workspaces=false
+              run: npm ci --include=optional --strict-allow-scripts --workspaces=false
 
             - name: Validate backend dependency tree
               working-directory: back-end
@@ -39,7 +43,7 @@ jobs:
 
             - name: Audit backend dependency tree
               working-directory: back-end
-              run: npm audit --omit=optional --workspaces=false
+              run: npm audit --include=optional --workspaces=false
 
     lint:
         runs-on: ubuntu-latest
@@ -59,6 +63,7 @@ jobs:
                   npm -v
                   npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
 
             - name: Install deps
               run: npm ci
@@ -67,7 +72,7 @@ jobs:
               run: npm run check:dependencies
 
             - name: Dependency security audit
-              run: npm audit --omit=optional
+              run: npm audit --include=optional
 
             # Root "lint" runs front-end and back-end lint
             - name: Lint
@@ -89,6 +94,7 @@ jobs:
               run: |
                   npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
 
             - name: Install deps
               run: npm ci
@@ -114,14 +120,11 @@ jobs:
                   cache: npm
                   registry-url: https://registry.npmjs.org/
 
-            # Only pin npm if compatible
-            - name: Pin npm version (if supported)
+            - name: Pin npm version
               run: |
-                  # optional guard:
-                  if [ $(node -v | cut -d. -f1 | sed 's/v//') -ge 20 ]; then
-                    npm i -g npm@12.0.1
-                  fi
+                  npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
 
             - name: Install deps
               run: npm ci
@@ -158,6 +161,7 @@ jobs:
               run: |
                   npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
 
             - name: Install deps
               run: npm ci
@@ -182,6 +186,7 @@ jobs:
               run: |
                   npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
 
             - name: Install deps
               run: npm ci
@@ -232,6 +237,7 @@ jobs:
               run: |
                   npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
 
             - name: Install deps
               run: npm ci
@@ -269,6 +275,7 @@ jobs:
               run: |
                   npm i -g npm@12.0.1
                   npm -v
+                  test "$(npm --version)" = "12.0.1"
 
             - name: Install deps
               run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,8 @@
 # Optional dependencies omitted by default
 #omit = ["optional"]
 
+strict-allow-scripts=true
+
 # Root workspace install-script approvals are recorded in package.json.
 # Standalone backend installs use back-end/.npmrc because npm ignores
 # workspace-level package.json approvals during a root install.

--- a/back-end/.npmrc
+++ b/back-end/.npmrc
@@ -1,1 +1,5 @@
-allow-scripts=argon2,esbuild
+strict-allow-scripts=true
+allow-scripts=argon2@0.44.0,esbuild@0.28.1,fsevents@2.3.3
+
+# CI and native release preparation apply this policy when they install the
+# standalone backend lockfile. Exact approvals are derived from that lockfile.

--- a/back-end/src/middleware/projectPayload.ts
+++ b/back-end/src/middleware/projectPayload.ts
@@ -25,6 +25,44 @@ interface ProjectPayloadConcurrencyOptions {
 	perIdentityLimit?: number;
 }
 
+export type CodeIdeProjectMutationAuthScope
+	= "account" | "managed" | "read-only";
+
+interface ProjectPayloadReservation {
+	claim: () => boolean;
+	takeOwnership: () => (() => void) | null;
+}
+
+const projectPayloadReservations = new WeakMap<
+	Request,
+	ProjectPayloadReservation
+>();
+
+function projectPayloadTransportClosed(
+	req: Request,
+	res: Parameters<RequestHandler>[1]
+): boolean {
+	return (
+		req.aborted
+		|| req.destroyed
+		|| res.destroyed
+		|| res.writableEnded
+	);
+}
+
+/** Classify the parsed regex mount, never the attacker-controlled raw target. */
+export function codeIdeProjectMutationAuthScope(
+	req: Request
+): CodeIdeProjectMutationAuthScope {
+	if (req.baseUrl.toLowerCase() === "/users/loggedin/python-projects") {
+		return "account";
+	}
+	if (/^\/users\/[^/]+\/python-projects$/i.test(req.baseUrl)) {
+		return "managed";
+	}
+	return "read-only";
+}
+
 export function isHeavyCodeIdeProjectPayload(
 	req: Request,
 	thresholdBytes = HEAVY_CODE_IDE_PROJECT_PAYLOAD_THRESHOLD_BYTES
@@ -46,11 +84,25 @@ export function isHeavyCodeIdeProjectPayload(
 }
 
 /**
- * Project admission runs after the signed session middleware but before route
- * authentication performs a database lookup. Use the signed account identity
- * when available and a normalized network key only as a fallback.
+ * Production authenticates project mutations before admission. Prefer that
+ * verified current-role identity; signed-session and normalized network keys
+ * remain defensive fallbacks for reusable middleware and isolated fixtures.
  */
 export function codeIdeProjectPayloadIdentity(req: Request): string {
+	const currentRoleAndID = [
+		["admin", req.currentAdmin?._id?.toString()],
+		["tutor", req.currentTutor?._id?.toString()],
+		["user", req.currentUser?._id?.toString()],
+		[
+			"course-code-learner",
+			req.currentCourseCodeLearner?._id?.toString()
+		]
+	].find(
+		(entry): entry is [string, string] =>
+			typeof entry[1] === "string" && entry[1].length > 0
+	);
+	if (currentRoleAndID) return `${currentRoleAndID[0]}:${currentRoleAndID[1]}`;
+
 	const session = req.session as CustomSession | undefined;
 	if (!session || !authenticatedSessionIsCurrent(session)) {
 		return `network:${ipKeyGenerator(
@@ -85,6 +137,44 @@ export function createCodeIdeProjectJsonParser(
 }
 
 /**
+ * Claim a successfully parsed, preauthorized mutation immediately before
+ * route dispatch. The transport fallback stays armed so unmatched routes and
+ * disconnects before terminal ownership cannot leak the slot.
+ */
+export const claimCodeIdeProjectPayloadReservation: RequestHandler
+	= (req, _res, next) => {
+		const reservation = projectPayloadReservations.get(req);
+		if (!reservation || reservation.claim()) next();
+	};
+
+/**
+ * Await the terminal project mutation while it owns the admitted payload slot.
+ * The terminal path takes exclusive ownership and removes the fallback before
+ * persistence. A request released during parsing/auth cannot mutate later.
+ */
+export function withCodeIdeProjectPayloadReservation(
+	handler: RequestHandler
+): RequestHandler {
+	return async (req, res, next) => {
+		const reservation = projectPayloadReservations.get(req);
+		if (!reservation) {
+			await handler(req, res, next);
+			return;
+		}
+
+		const release = reservation.takeOwnership();
+		if (!release) return;
+
+		try {
+			await handler(req, res, next);
+		}
+		finally {
+			release();
+		}
+	};
+}
+
+/**
  * Admit one heavy body process-wide. Normal autosaves retain a wider tier,
  * while each signed identity remains bounded. Slots stay held through the
  * response because the parsed body remains reachable during validation/write.
@@ -114,6 +204,7 @@ export function createCodeIdeProjectPayloadConcurrencyGuard(
 	let activeNormalTotal = 0;
 
 	return (req, res, next) => {
+		if (projectPayloadTransportClosed(req, res)) return;
 		const isHeavy = isHeavyCodeIdeProjectPayload(
 			req,
 			heavyThresholdBytes
@@ -148,10 +239,10 @@ export function createCodeIdeProjectPayloadConcurrencyGuard(
 		}
 		activeByIdentity.set(identity, activeForIdentity);
 
-		let released = false;
-		const release = () => {
-			if (released) return;
-			released = true;
+		let slotReleased = false;
+		const releaseSlot = () => {
+			if (slotReleased) return;
+			slotReleased = true;
 			const current = activeByIdentity.get(identity);
 			if (isHeavy) {
 				activeHeavyTotal -= 1;
@@ -169,14 +260,59 @@ export function createCodeIdeProjectPayloadConcurrencyGuard(
 			}
 		};
 
-		req.once("aborted", release);
-		res.once("close", release);
-		res.once("finish", release);
+		let reservationState: "available" | "claimed" | "owned" | "released"
+			= "available";
+		const removeFallbackListeners = () => {
+			req.removeListener("aborted", releaseBeforeOwnership);
+			res.removeListener("close", releaseBeforeOwnership);
+			res.removeListener("finish", releaseBeforeOwnership);
+		};
+		function releaseBeforeOwnership() {
+			if (
+				reservationState !== "available"
+				&& reservationState !== "claimed"
+			) {
+				return;
+			}
+			reservationState = "released";
+			removeFallbackListeners();
+			releaseSlot();
+		}
+		const reservation: ProjectPayloadReservation = {
+			claim: () => {
+				if (projectPayloadTransportClosed(req, res)) {
+					releaseBeforeOwnership();
+					return false;
+				}
+				if (reservationState !== "available") return false;
+				reservationState = "claimed";
+				return true;
+			},
+			takeOwnership: () => {
+				if (projectPayloadTransportClosed(req, res)) {
+					releaseBeforeOwnership();
+					return null;
+				}
+				if (reservationState !== "claimed") return null;
+				reservationState = "owned";
+				removeFallbackListeners();
+				return () => {
+					if (reservationState !== "owned") return;
+					reservationState = "released";
+					projectPayloadReservations.delete(req);
+					releaseSlot();
+				};
+			}
+		};
+		projectPayloadReservations.set(req, reservation);
+		req.once("aborted", releaseBeforeOwnership);
+		res.once("close", releaseBeforeOwnership);
+		res.once("finish", releaseBeforeOwnership);
 		try {
 			next();
 		}
 		catch (error) {
-			release();
+			releaseBeforeOwnership();
 			throw error;
 		}
 	};

--- a/back-end/src/routes/userRoutes.ts
+++ b/back-end/src/routes/userRoutes.ts
@@ -49,12 +49,34 @@ import {
 	validTutorOrAdminSession,
 	validUser
 } from "../middleware/auth.js";
+import { withCodeIdeProjectPayloadReservation } from "../middleware/projectPayload.js";
 import {
 	createSignupLimiter,
 	createUserCourseAccessLimiter
 } from "../middleware/rateLimiters.js";
 
 const router: Router = express.Router();
+
+const validProjectAccountSession: express.RequestHandler = (req, res, next) => {
+	if (
+		req.currentAdmin
+		|| req.currentTutor
+		|| req.currentUser
+		|| req.currentCourseCodeLearner
+	) {
+		next();
+		return;
+	}
+	return validAccountSession(req, res, next);
+};
+
+const validManagedProjectSession: express.RequestHandler = (req, res, next) => {
+	if (req.currentAdmin || req.currentTutor) {
+		next();
+		return;
+	}
+	return validTutorOrAdminSession(req, res, next);
+};
 
 // Rate limiter for sensitive endpoints (e.g. 100 requests per 15 minutes)
 const userCourseAccessLimiter = createUserCourseAccessLimiter();
@@ -72,11 +94,27 @@ router.get("/python-projects/shared/:shareID", getSharedPythonProject);
 // Persist logged-in account Code IDE projects. Keep these before the
 // managed /:userID/python-projects routes so "loggedin" is not parsed as an ID.
 router.get("/loggedin/python-projects", validAccountSession, listPythonProjects);
-router.post("/loggedin/python-projects", validAccountSession, createPythonProject);
+router.post(
+	"/loggedin/python-projects",
+	validProjectAccountSession,
+	withCodeIdeProjectPayloadReservation(createPythonProject)
+);
 router.get("/loggedin/python-projects/:projectID", validAccountSession, getPythonProject);
-router.put("/loggedin/python-projects/:projectID", validAccountSession, updatePythonProject);
-router.put("/loggedin/python-projects/:projectID/share", validAccountSession, updatePythonProjectShare);
-router.delete("/loggedin/python-projects/:projectID", validAccountSession, deletePythonProject);
+router.put(
+	"/loggedin/python-projects/:projectID",
+	validProjectAccountSession,
+	withCodeIdeProjectPayloadReservation(updatePythonProject)
+);
+router.put(
+	"/loggedin/python-projects/:projectID/share",
+	validProjectAccountSession,
+	withCodeIdeProjectPayloadReservation(updatePythonProjectShare)
+);
+router.delete(
+	"/loggedin/python-projects/:projectID",
+	validProjectAccountSession,
+	withCodeIdeProjectPayloadReservation(deletePythonProject)
+);
 router.get("/loggedin/python-project-reviews", validAccountSession, listVisiblePythonProjectReviews);
 router.get(
 	"/loggedin/python-project-reviews/:reviewID",
@@ -123,8 +161,16 @@ router.get(
 	validTutorOrAdminSession,
 	getManagedPythonProject
 );
-router.post("/:userID/python-projects/:projectID/review", validTutorOrAdminSession, createPythonProjectReview);
-router.put("/:userID/python-projects/:projectID/review/:reviewID", validTutorOrAdminSession, updatePythonProjectReview);
+router.post(
+	"/:userID/python-projects/:projectID/review",
+	validManagedProjectSession,
+	withCodeIdeProjectPayloadReservation(createPythonProjectReview)
+);
+router.put(
+	"/:userID/python-projects/:projectID/review/:reviewID",
+	validManagedProjectSession,
+	withCodeIdeProjectPayloadReservation(updatePythonProjectReview)
+);
 
 // Delete the user by the user themselves
 router.delete("/user/:userID", validUser, deleteOwnUser);

--- a/back-end/src/server.ts
+++ b/back-end/src/server.ts
@@ -7,8 +7,14 @@ import mongoose from "mongoose";
 
 import { codeIdeAssetsProxy, pythonIdeAssetsProxy } from "./controllers/common/pythonIdeAssetsProxy.js";
 import { quoteProxy } from "./controllers/common/quoteProxy.js";
+import {
+	validAccountSession,
+	validTutorOrAdminSession
+} from "./middleware/auth.js";
 import { apiNotFound } from "./middleware/notFound.js";
 import {
+	claimCodeIdeProjectPayloadReservation,
+	codeIdeProjectMutationAuthScope,
 	createCodeIdeProjectJsonParser,
 	createCodeIdeProjectPayloadConcurrencyGuard
 } from "./middleware/projectPayload.js";
@@ -91,6 +97,27 @@ async function main() {
 	const projectPayloadConcurrencyGuard
 		= createCodeIdeProjectPayloadConcurrencyGuard();
 	const projectBodyMethods = new Set(["PATCH", "POST", "PUT"]);
+	const projectMutationMethods = new Set(["DELETE", ...projectBodyMethods]);
+	const authenticateProjectMutation: express.RequestHandler = (
+		req,
+		res,
+		next
+	) => {
+		if (!projectMutationMethods.has(req.method.toUpperCase())) {
+			next();
+			return;
+		}
+
+		const authScope = codeIdeProjectMutationAuthScope(req);
+		if (authScope === "account") {
+			return validAccountSession(req, res, next);
+		}
+		if (authScope === "managed") {
+			return validTutorOrAdminSession(req, res, next);
+		}
+		res.setHeader("Allow", "GET");
+		res.status(405).json({ message: "Project mutation is not allowed here" });
+	};
 	const limitProjectBody
 		= (limiter: express.RequestHandler) =>
 			(
@@ -112,9 +139,11 @@ async function main() {
 		},
 		projectDataAccessLimiter,
 		createCodeIdeProjectAccountWriteLimiter(),
+		authenticateProjectMutation,
 		limitProjectBody(heavyProjectPayloadLimiter),
 		limitProjectBody(projectPayloadConcurrencyGuard),
-		limitProjectBody(projectJson)
+		limitProjectBody(projectJson),
+		limitProjectBody(claimCodeIdeProjectPayloadReservation)
 	);
 
 	// Parse only after coarse network, request-origin, and per-account checks.

--- a/back-end/test/project-payload-middleware.spec.test.ts
+++ b/back-end/test/project-payload-middleware.spec.test.ts
@@ -2,6 +2,7 @@ import type { Server } from "node:http";
 import { request } from "node:http";
 import { gzipSync } from "node:zlib";
 import express from "express";
+import rateLimit from "express-rate-limit";
 import { describe, expect, it, vi } from "vitest";
 import {
 	claimCodeIdeProjectPayloadReservation,
@@ -333,14 +334,18 @@ function postRawTarget(baseUrl: string, target: string): Promise<number> {
 describe("Code IDE project payload middleware", () => {
 	it("classifies parsed mounts for unusual raw request targets", async () => {
 		const app = express();
-		app.use(codeIdeProjectApiMountPath, (req, res) => {
-			const scope = codeIdeProjectMutationAuthScope(req);
-			if (scope === "read-only") {
-				res.sendStatus(405);
-				return;
+		app.use(
+			codeIdeProjectApiMountPath,
+			rateLimit({ limit: 100, windowMs: 60_000 }),
+			(req, res) => {
+				const scope = codeIdeProjectMutationAuthScope(req);
+				if (scope === "read-only") {
+					res.sendStatus(405);
+					return;
+				}
+				res.sendStatus(204);
 			}
-			res.sendStatus(204);
-		});
+		);
 		app.use((_req, res) => res.sendStatus(404));
 
 		const server = await new Promise<Server>(resolve => {

--- a/back-end/test/project-payload-middleware.spec.test.ts
+++ b/back-end/test/project-payload-middleware.spec.test.ts
@@ -4,10 +4,16 @@ import { gzipSync } from "node:zlib";
 import express from "express";
 import { describe, expect, it, vi } from "vitest";
 import {
+	claimCodeIdeProjectPayloadReservation,
+	codeIdeProjectMutationAuthScope,
 	createCodeIdeProjectJsonParser,
-	createCodeIdeProjectPayloadConcurrencyGuard
+	createCodeIdeProjectPayloadConcurrencyGuard,
+	withCodeIdeProjectPayloadReservation
 } from "../src/middleware/projectPayload.js";
-import { createCodeIdeHeavyProjectPayloadLimiter } from "../src/middleware/rateLimiters.js";
+import {
+	codeIdeProjectApiMountPath,
+	createCodeIdeHeavyProjectPayloadLimiter
+} from "../src/middleware/rateLimiters.js";
 
 interface PayloadAppOptions {
 	globalLimit?: number;
@@ -21,8 +27,35 @@ interface PayloadAppOptions {
 
 interface PayloadAppControls {
 	releaseHeld: () => void;
+	releasePreGuard: () => void;
 	saved: ReturnType<typeof vi.fn>;
+	waitForAbortedCount: (count: number) => Promise<void>;
+	waitForClosedCount: (count: number) => Promise<void>;
 	waitForHeldCount: (count: number) => Promise<void>;
+	waitForParserEntryCount: (count: number) => Promise<void>;
+	waitForPreGuardContinuedCount: (count: number) => Promise<void>;
+	waitForPreGuardCount: (count: number) => Promise<void>;
+	waitForSettledCount: (count: number) => Promise<void>;
+}
+
+function createCountSignal() {
+	let count = 0;
+	const waiters: Array<{ count: number; resolve: () => void }> = [];
+	return {
+		mark: () => {
+			count += 1;
+			for (const waiter of waiters.splice(0)) {
+				if (count >= waiter.count) waiter.resolve();
+				else waiters.push(waiter);
+			}
+		},
+		waitFor: (expectedCount: number) => {
+			if (count >= expectedCount) return Promise.resolve();
+			return new Promise<void>(resolve => {
+				waiters.push({ count: expectedCount, resolve });
+			});
+		}
+	};
 }
 
 async function withPayloadApp<T>(
@@ -32,32 +65,36 @@ async function withPayloadApp<T>(
 	const app = express();
 	const saved = vi.fn();
 	const heavyThresholdBytes = options.heavyThresholdBytes ?? 1_024;
-	let heldCount = 0;
+	const aborted = createCountSignal();
+	const closed = createCountSignal();
+	const held = createCountSignal();
+	const parserEntry = createCountSignal();
+	const preGuard = createCountSignal();
+	const preGuardContinued = createCountSignal();
+	const settled = createCountSignal();
 	let releaseHeld = () => undefined;
+	let releasePreGuard = () => undefined;
 	const heldRelease = new Promise<void>(resolve => {
 		releaseHeld = resolve;
 	});
-	const heldWaiters: Array<{ count: number; resolve: () => void }> = [];
-	const markHeld = () => {
-		heldCount += 1;
-		for (const waiter of heldWaiters.splice(0)) {
-			if (heldCount >= waiter.count) waiter.resolve();
-			else heldWaiters.push(waiter);
-		}
-	};
-	const waitForHeldCount = (count: number) => {
-		if (heldCount >= count) return Promise.resolve();
-		return new Promise<void>(resolve => {
-			heldWaiters.push({ count, resolve });
-		});
-	};
-
+	const preGuardRelease = new Promise<void>(resolve => {
+		releasePreGuard = resolve;
+	});
 	app.set("trust proxy", 1);
-	app.use("/users/loggedin/python-projects", (req, _res, next) => {
+	app.use("/users/loggedin/python-projects", async (req, res, next) => {
 		req.session = {
 			authenticatedSessionExpiresAt: Date.now() + 60_000,
 			userID: req.get("X-Test-User-ID") ?? "user-one"
 		} as typeof req.session;
+		if (req.get("X-Hold-Pre-Guard") === "1") {
+			req.once("aborted", aborted.mark);
+			res.once("close", closed.mark);
+			preGuard.mark();
+			await preGuardRelease;
+			next();
+			preGuardContinued.mark();
+			return;
+		}
 		next();
 	});
 	app.use(
@@ -74,18 +111,51 @@ async function withPayloadApp<T>(
 			normalPerIdentityLimit: options.normalPerIdentityLimit,
 			perIdentityLimit: options.perIdentityLimit ?? 1
 		}),
-		createCodeIdeProjectJsonParser(options.parserLimit ?? "8kb")
+		(req, res, next) => {
+			req.once("aborted", aborted.mark);
+			res.once("close", closed.mark);
+			parserEntry.mark();
+			next();
+		},
+		createCodeIdeProjectJsonParser(options.parserLimit ?? "8kb"),
+		claimCodeIdeProjectPayloadReservation,
+		async (req, res, next) => {
+			if (req.get("X-Reject-After-Parse") !== "1") {
+				next();
+				return;
+			}
+			await Promise.resolve();
+			res.sendStatus(403);
+		}
 	);
 	// A project parsed above must not fall through to the smaller global parser.
 	app.use(express.json({ limit: "128b" }));
-	app.post("/users/loggedin/python-projects", async (req, res) => {
-		saved();
-		if (req.get("X-Hold-Response") === "1") {
-			markHeld();
-			await heldRelease;
-		}
-		res.json({ contentLength: req.body.files[0].content.length });
-	});
+	app.post(
+		"/users/loggedin/python-projects",
+		withCodeIdeProjectPayloadReservation(async (req, res) => {
+			saved();
+			try {
+				if (req.get("X-Hold-Response") === "1") {
+					held.mark();
+					await heldRelease;
+				}
+				if (!res.destroyed) {
+					res.json({
+						contentLength: req.body.files[0].content.length
+					});
+				}
+			} finally {
+				settled.mark();
+			}
+		})
+	);
+	app.post(
+		"/users/loggedin/python-projects/decoded/:projectID",
+		withCodeIdeProjectPayloadReservation((_req, res) => {
+			saved();
+			res.sendStatus(204);
+		})
+	);
 	app.use(
 		(
 			error: { status?: number },
@@ -107,12 +177,20 @@ async function withPayloadApp<T>(
 
 	try {
 		return await run(`http://127.0.0.1:${address.port}`, {
-			releaseHeld,
-			saved,
-			waitForHeldCount
+				releaseHeld,
+				releasePreGuard,
+				saved,
+			waitForAbortedCount: aborted.waitFor,
+			waitForClosedCount: closed.waitFor,
+			waitForHeldCount: held.waitFor,
+				waitForParserEntryCount: parserEntry.waitFor,
+				waitForPreGuardContinuedCount: preGuardContinued.waitFor,
+				waitForPreGuardCount: preGuard.waitFor,
+			waitForSettledCount: settled.waitFor
 		});
 	} finally {
 		releaseHeld();
+		releasePreGuard();
 		await new Promise<void>((resolve, reject) => {
 			server.close(error => (error ? reject(error) : resolve()));
 		});
@@ -182,7 +260,129 @@ function postChunkedProject(
 	});
 }
 
+function startAbortableProject(
+	baseUrl: string,
+	content: string,
+	headers: Record<string, string>,
+	completeBody: boolean,
+	pathSuffix = ""
+) {
+	const url = new URL(
+		`${baseUrl}/users/loggedin/python-projects${pathSuffix}`
+	);
+	const body = projectBody(content);
+	let clientRequest: ReturnType<typeof request>;
+	const completed = new Promise<void>(resolve => {
+		let done = false;
+		const settle = () => {
+			if (done) return;
+			done = true;
+			resolve();
+		};
+		clientRequest = request(
+			{
+				headers: {
+					"content-length": Buffer.byteLength(body).toString(),
+					"content-type": "application/json",
+					...headers
+				},
+				host: url.hostname,
+				method: "POST",
+				path: url.pathname,
+				port: url.port
+			},
+			res => {
+				res.resume();
+				res.once("end", settle);
+			}
+		);
+		clientRequest.once("close", settle);
+		clientRequest.once("error", settle);
+		if (completeBody) clientRequest.end(body);
+		else clientRequest.write(body.slice(0, Math.ceil(body.length / 2)));
+	});
+
+	return {
+		abort: () => clientRequest.destroy(),
+		completed
+	};
+}
+
+function waitForImmediate(): Promise<void> {
+	return new Promise(resolve => setImmediate(resolve));
+}
+
+function postRawTarget(baseUrl: string, target: string): Promise<number> {
+	const url = new URL(baseUrl);
+	return new Promise((resolve, reject) => {
+		const req = request({
+			headers: { "content-length": "0" },
+			host: url.hostname,
+			method: "POST",
+			path: target,
+			port: url.port
+		}, res => {
+			res.resume();
+			res.once("end", () => resolve(res.statusCode ?? 0));
+		});
+		req.once("error", reject);
+		req.end();
+	});
+}
+
 describe("Code IDE project payload middleware", () => {
+	it("classifies parsed mounts for unusual raw request targets", async () => {
+		const app = express();
+		app.use(codeIdeProjectApiMountPath, (req, res) => {
+			const scope = codeIdeProjectMutationAuthScope(req);
+			if (scope === "read-only") {
+				res.sendStatus(405);
+				return;
+			}
+			res.sendStatus(204);
+		});
+		app.use((_req, res) => res.sendStatus(404));
+
+		const server = await new Promise<Server>(resolve => {
+			const instance = app.listen(0, "127.0.0.1", () => resolve(instance));
+		});
+		const address = server.address();
+		if (!address || typeof address === "string") {
+			throw new TypeError("Test server did not bind to an IPv4 port");
+		}
+		const baseUrl = `http://127.0.0.1:${address.port}`;
+
+		try {
+			expect(await postRawTarget(
+				baseUrl,
+				`${baseUrl}/users/loggedin/python-projects`
+			)).toBe(204);
+			expect(await postRawTarget(
+				baseUrl,
+				"/users/loggedin/python-projects#fragment"
+			)).toBe(204);
+			expect(await postRawTarget(
+				baseUrl,
+				"/users/not-an-object-id/python-projects/project/review"
+			)).toBe(204);
+			for (const target of [
+				"/users/python-projects/shared/project",
+				"/users/loggedin/python-project-reviews/review"
+			]) {
+				expect(await postRawTarget(baseUrl, target)).toBe(405);
+			}
+			expect(await postRawTarget(
+				baseUrl,
+				"/users//python-projects"
+			)).toBe(404);
+		}
+		finally {
+			await new Promise<void>((resolve, reject) => {
+				server.close(error => error ? reject(error) : resolve());
+			});
+		}
+	});
+
 	it("preserves normal autosaves above the global parser limit", async () => {
 		await withPayloadApp(
 			{ heavyThresholdBytes: 2_048 },
@@ -193,8 +393,7 @@ describe("Code IDE project payload middleware", () => {
 				]);
 
 				expect(responses.map(response => response.status)).toEqual([
-					200,
-					200
+					200, 200
 				]);
 				expect(controls.saved).toHaveBeenCalledTimes(2);
 			}
@@ -246,6 +445,91 @@ describe("Code IDE project payload middleware", () => {
 		});
 	});
 
+	it("keeps an aborted terminal save reserved until persistence settles", async () => {
+		await withPayloadApp({}, async (baseUrl, controls) => {
+			const first = startAbortableProject(
+				baseUrl,
+				"x".repeat(3_000),
+				{
+					"X-Hold-Response": "1",
+					"X-Test-User-ID": "user-one"
+				},
+				true
+			);
+			await controls.waitForHeldCount(1);
+			first.abort();
+			await Promise.all([
+				first.completed,
+				controls.waitForClosedCount(1)
+			]);
+
+			const overlapping = await postProject(baseUrl, "y".repeat(3_000), {
+				"X-Test-User-ID": "user-two"
+			});
+			expect(overlapping.status).toBe(429);
+			expect(controls.saved).toHaveBeenCalledTimes(1);
+
+			controls.releaseHeld();
+			await controls.waitForSettledCount(1);
+			await waitForImmediate();
+			const afterPersistence = await postProject(
+				baseUrl,
+				"z".repeat(3_000),
+				{ "X-Test-User-ID": "user-two" }
+			);
+			expect(afterPersistence.status).toBe(200);
+			expect(controls.saved).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	it("releases an aborted in-flight parser reservation without saving", async () => {
+		await withPayloadApp({}, async (baseUrl, controls) => {
+			const partial = startAbortableProject(
+				baseUrl,
+				"x".repeat(3_000),
+				{ "X-Test-User-ID": "user-one" },
+				false
+			);
+			await controls.waitForParserEntryCount(1);
+			partial.abort();
+			await Promise.all([
+				partial.completed,
+				controls.waitForAbortedCount(1)
+			]);
+
+			const next = await postProject(baseUrl, "y".repeat(3_000), {
+				"X-Test-User-ID": "user-two"
+			});
+			expect(next.status).toBe(200);
+			expect(controls.saved).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it("refuses admission after an async pre-parser auth abort", async () => {
+		await withPayloadApp({}, async (baseUrl, controls) => {
+			const partial = startAbortableProject(
+				baseUrl,
+				"x".repeat(3_000),
+				{ "X-Hold-Pre-Guard": "1" },
+				false,
+				"/missing"
+			);
+			await controls.waitForPreGuardCount(1);
+			partial.abort();
+			await Promise.all([
+				partial.completed,
+				controls.waitForAbortedCount(1),
+				controls.waitForClosedCount(1)
+			]);
+			controls.releasePreGuard();
+			await controls.waitForPreGuardContinuedCount(1);
+
+			const next = await postProject(baseUrl, "y".repeat(3_000));
+			expect(next.status).toBe(200);
+			expect(controls.saved).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	it("treats chunked requests as heavy", async () => {
 		await withPayloadApp(
 			{ heavyThresholdBytes: 2_048 },
@@ -274,7 +558,58 @@ describe("Code IDE project payload middleware", () => {
 			);
 
 			expect(response.status).toBe(415);
-			expect(controls.saved).not.toHaveBeenCalled();
+			const next = await postProject(baseUrl, "y".repeat(3_000));
+			expect(next.status).toBe(200);
+			expect(controls.saved).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it("releases a claimed reservation when no terminal route matches", async () => {
+		await withPayloadApp({}, async (baseUrl, controls) => {
+			const missing = await fetch(
+				`${baseUrl}/users/loggedin/python-projects/missing`,
+				{
+					body: projectBody("x".repeat(3_000)),
+					headers: { "content-type": "application/json" },
+					method: "POST"
+				}
+			);
+			expect(missing.status).toBe(404);
+
+			const next = await postProject(baseUrl, "y".repeat(3_000));
+			expect(next.status).toBe(200);
+			expect(controls.saved).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it("releases a claimed reservation after malformed route decoding", async () => {
+		await withPayloadApp({}, async (baseUrl, controls) => {
+			const malformed = await fetch(
+				`${baseUrl}/users/loggedin/python-projects/decoded/%E0%A4%A`,
+				{
+					body: projectBody("x".repeat(3_000)),
+					headers: { "content-type": "application/json" },
+					method: "POST"
+				}
+			);
+			expect(malformed.status).toBe(400);
+
+			const next = await postProject(baseUrl, "y".repeat(3_000));
+			expect(next.status).toBe(200);
+			expect(controls.saved).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it("releases a claimed reservation after async route rejection", async () => {
+		await withPayloadApp({}, async (baseUrl, controls) => {
+			const rejected = await postProject(baseUrl, "x".repeat(3_000), {
+				"X-Reject-After-Parse": "1"
+			});
+			expect(rejected.status).toBe(403);
+
+			const next = await postProject(baseUrl, "y".repeat(3_000));
+			expect(next.status).toBe(200);
+			expect(controls.saved).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -282,13 +617,12 @@ describe("Code IDE project payload middleware", () => {
 		await withPayloadApp(
 			{ parserLimit: "2kb" },
 			async (baseUrl, controls) => {
-				const response = await postProject(
-					baseUrl,
-					"x".repeat(3_000)
-				);
+				const response = await postProject(baseUrl, "x".repeat(3_000));
 
 				expect(response.status).toBe(413);
-				expect(controls.saved).not.toHaveBeenCalled();
+				const next = await postProject(baseUrl, "y".repeat(1_500));
+				expect(next.status).toBe(200);
+				expect(controls.saved).toHaveBeenCalledTimes(1);
 			}
 		);
 	});

--- a/back-end/test/python-project-routes.spec.test.ts
+++ b/back-end/test/python-project-routes.spec.test.ts
@@ -500,6 +500,64 @@ describe("Python project routes", () => {
 		expect(serverSource).toContain('bodyParser.json({ limit: "1mb" })');
 	});
 
+	it("composes pre-parser auth and terminal reservation ownership", () => {
+		const serverSource = readFileSync(
+			resolve(__dirname, "../src/server.ts"),
+			"utf8"
+		);
+		const routeSource = readFileSync(
+			resolve(__dirname, "../src/routes/userRoutes.ts"),
+			"utf8"
+		);
+		const accountLimiter = serverSource.indexOf(
+			"createCodeIdeProjectAccountWriteLimiter(),"
+		);
+		const authentication = serverSource.indexOf(
+			"authenticateProjectMutation,",
+			accountLimiter
+		);
+		const heavyLimiter = serverSource.indexOf(
+			"limitProjectBody(heavyProjectPayloadLimiter)",
+			authentication
+		);
+		const concurrency = serverSource.indexOf(
+			"limitProjectBody(projectPayloadConcurrencyGuard)",
+			heavyLimiter
+		);
+		const parser = serverSource.indexOf(
+			"limitProjectBody(projectJson)",
+			concurrency
+		);
+		const claim = serverSource.indexOf(
+			"limitProjectBody(claimCodeIdeProjectPayloadReservation)",
+			parser
+		);
+		const routes = serverSource.indexOf(
+			'app.use("/users", userRoutes)',
+			claim
+		);
+
+		expect(accountLimiter).toBeGreaterThan(-1);
+		expect(authentication).toBeGreaterThan(accountLimiter);
+		expect(heavyLimiter).toBeGreaterThan(authentication);
+		expect(concurrency).toBeGreaterThan(heavyLimiter);
+		expect(parser).toBeGreaterThan(concurrency);
+		expect(claim).toBeGreaterThan(parser);
+		expect(routes).toBeGreaterThan(claim);
+
+		const compactRoutes = routeSource.replace(/\s+/g, " ");
+		for (const route of [
+			'router.post( "/loggedin/python-projects", validProjectAccountSession, withCodeIdeProjectPayloadReservation(createPythonProject) )',
+			'router.put( "/loggedin/python-projects/:projectID", validProjectAccountSession, withCodeIdeProjectPayloadReservation(updatePythonProject) )',
+			'router.put( "/loggedin/python-projects/:projectID/share", validProjectAccountSession, withCodeIdeProjectPayloadReservation(updatePythonProjectShare) )',
+			'router.delete( "/loggedin/python-projects/:projectID", validProjectAccountSession, withCodeIdeProjectPayloadReservation(deletePythonProject) )',
+			'router.post( "/:userID/python-projects/:projectID/review", validManagedProjectSession, withCodeIdeProjectPayloadReservation(createPythonProjectReview) )',
+			'router.put( "/:userID/python-projects/:projectID/review/:reviewID", validManagedProjectSession, withCodeIdeProjectPayloadReservation(updatePythonProjectReview) )'
+		]) {
+			expect(compactRoutes).toContain(route);
+		}
+	});
+
 	it("rejects files that collide with browser runtime shim modules", async () => {
 		await withPythonProjectRoute(async baseUrl => {
 			for (const reservedFileName of [

--- a/front-end/test/java-ide-runtime.spec.test.ts
+++ b/front-end/test/java-ide-runtime.spec.test.ts
@@ -2192,11 +2192,11 @@ cols=3`
 		].join("\n");
 
 		expect(backendSource).toContain('app.get("/healthz"');
-		expect(backendSource).toContain(
-			'router.post("/loggedin/python-projects"'
+		expect(backendSource).toMatch(
+			/router[.]post[(]\s*"\/loggedin\/python-projects"/u
 		);
-		expect(backendSource).toContain(
-			'router.put("/loggedin/python-projects/:projectID"'
+		expect(backendSource).toMatch(
+			/router[.]put[(]\s*"\/loggedin\/python-projects\/:projectID"/u
 		);
 		expect(backendSource).toContain(
 			'router.get("/python-projects/shared/:shareID"'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4740,6 +4740,8 @@
 		},
 		"node_modules/argon2": {
 			"version": "0.44.0",
+			"resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+			"integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5972,6 +5974,8 @@
 		},
 		"node_modules/cypress": {
 			"version": "15.19.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-15.19.0.tgz",
+			"integrity": "sha512-kjy1u3SWlMRWS5qffH3U+bXx1PqPP7qwhIzEY3UtERcW2r/8zy5uk6uSwa75pYXJyYFVP1SO8mAn/avZUvUbfg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6569,6 +6573,8 @@
 		},
 		"node_modules/esbuild": {
 			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -7985,6 +7991,9 @@
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12191,6 +12200,8 @@
 		},
 		"node_modules/puppeteer": {
 			"version": "24.43.1",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
+			"integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -12812,6 +12823,8 @@
 		},
 		"node_modules/simple-git-hooks": {
 			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
+			"integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -14564,6 +14577,8 @@
 		},
 		"node_modules/vue-demi": {
 			"version": "0.14.10",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+			"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -85,12 +85,13 @@
 	"allowScripts": {
 		"connect-mongo": false,
 		"express-rate-limit": false,
-		"argon2": true,
-		"cypress": true,
-		"esbuild": true,
-		"puppeteer": true,
-		"simple-git-hooks": true,
-		"vue-demi": true
+		"argon2@0.44.0": true,
+		"cypress@15.19.0": true,
+		"esbuild@0.28.1": true,
+		"fsevents@2.3.3": true,
+		"puppeteer@24.43.1": true,
+		"simple-git-hooks@2.13.1": true,
+		"vue-demi@0.14.10": true
 	},
 	"devDependencies": {
 		"@antfu/eslint-config": "^8.2.0",

--- a/scripts/prepare-native-release.sh
+++ b/scripts/prepare-native-release.sh
@@ -106,6 +106,7 @@ install -m 0644 "$classes_build_source/front-end/package.json" "$classes_staging
 install -m 0644 \
 	"$classes_build_source/back-end/package.json" \
 	"$classes_build_source/back-end/package-lock.json" \
+	"$classes_build_source/back-end/.npmrc" \
 	"$classes_staging_candidate/back-end/"
 install -m 0755 \
 	"$classes_build_source/scripts/verify-native-source.sh" \
@@ -120,6 +121,7 @@ classes_npm "$classes_staging_candidate/back-end" ci \
 	--omit=dev \
 	--include=optional \
 	--strict-allow-scripts
+rm -f -- "$classes_staging_candidate/back-end/.npmrc"
 rm -rf -- "$classes_staging_candidate/back-end/node_modules/.bin"
 node "$classes_staging_candidate/scripts/verify-native-release.mjs" \
 	--write \

--- a/test/native-production-deployment.test.mjs
+++ b/test/native-production-deployment.test.mjs
@@ -99,6 +99,22 @@ test("prepare and promotion scripts enforce exact provenance and rollback gates"
 	assert.match(prepare, /run audit/u);
 	assert.match(prepare, /classes_staging_candidate\/back-end" ci/u);
 	assert.match(prepare, /back-end\/node_modules\/[.]bin/u);
+	const policyCopy = prepare.search(
+		/^\t"\$classes_build_source\/back-end\/[.]npmrc" \\$/mu
+	);
+	const runtimeInstall = prepare.search(
+		/^classes_npm "\$classes_staging_candidate\/back-end" ci \\$/mu
+	);
+	const policyRemoval = prepare.search(
+		/^rm -f -- "\$classes_staging_candidate\/back-end\/[.]npmrc"$/mu
+	);
+	const manifestWrite = prepare.search(
+		/^node "\$classes_staging_candidate\/scripts\/verify-native-release[.]mjs" \\$/mu
+	);
+	assert.ok(policyCopy >= 0 && policyCopy < runtimeInstall);
+	assert.ok(runtimeInstall < policyRemoval && policyRemoval < manifestWrite);
+	assert.match(prepare.slice(runtimeInstall, policyRemoval), /^\t--include=optional \\$/mu);
+	assert.match(prepare.slice(runtimeInstall, policyRemoval), /^\t--strict-allow-scripts$/mu);
 	assert.match(promote, /Candidate must remain inside the managed [.]candidates directory/u);
 	assert.match(promote, /verify-native-source[.]sh/u);
 	assert.match(promote, /Promotion requires an existing current release symlink for rollback/u);
@@ -291,6 +307,19 @@ test("internal manifest detects payload drift and stays out of public output", a
 	assert.notEqual(rejectedPayload.status, 0);
 	assert.match(rejectedPayload.stderr, /unsupported entry/u);
 	await fs.rm(path.join(candidate, "unchecked-top-level.sh"));
+
+	await fs.copyFile(
+		path.join(repositoryRoot, "back-end/.npmrc"),
+		path.join(candidate, "back-end/.npmrc")
+	);
+	rejectedPayload = spawnSync(
+		process.execPath,
+		[verifier, "--write", "--tag", "v2.7.205", "--revision", "a".repeat(40), candidate],
+		{ encoding: "utf8" }
+	);
+	assert.notEqual(rejectedPayload.status, 0);
+	assert.match(rejectedPayload.stderr, /unsupported entry back-end\/\.npmrc/u);
+	await fs.rm(path.join(candidate, "back-end/.npmrc"));
 
 	await fs.symlink(
 		path.join(candidate, "package.json"),

--- a/test/standalone-backend-install-policy.test.mjs
+++ b/test/standalone-backend-install-policy.test.mjs
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+// This executable configuration test intentionally uses Node's test runner.
+// eslint-disable-next-line test/no-import-node-test
+import test from "node:test";
+
+const repositoryRoot = resolve(import.meta.dirname, "..");
+const exactInstallScriptPins = [
+	"argon2@0.44.0",
+	"esbuild@0.28.1",
+	"fsevents@2.3.3"
+];
+
+function read(relativePath) {
+	return readFileSync(join(repositoryRoot, relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+	return JSON.parse(read(relativePath));
+}
+
+function packageNameFromLockPath(location) {
+	const marker = "node_modules/";
+	const packagePath = location.slice(
+		location.lastIndexOf(marker) + marker.length
+	);
+	const segments = packagePath.split("/");
+	return segments[0].startsWith("@")
+		? `${segments[0]}/${segments[1]}`
+		: segments[0];
+}
+
+function installScriptPins(lockfile) {
+	const pins = installScriptOccurrences(lockfile).map(
+		({ name, version }) => `${name}@${version}`
+	);
+	return [...new Set(pins)].sort();
+}
+
+function installScriptOccurrences(lockfile) {
+	return Object.entries(lockfile.packages)
+		.filter(
+			([location, metadata]) =>
+				location.includes("node_modules/")
+				&& metadata.hasInstallScript === true
+		)
+		.map(([location, metadata]) => ({
+			location,
+			name: packageNameFromLockPath(location),
+			version: metadata.version
+		}));
+}
+
+function installedPackagePins(lockfile) {
+	const pins = Object.entries(lockfile.packages)
+		.filter(([location]) => location.includes("node_modules/"))
+		.map(
+			([location, metadata]) =>
+				`${packageNameFromLockPath(location)}@${metadata.version}`
+		);
+	return new Set(pins);
+}
+
+function exactPackageIdentity(identity) {
+	const separator = identity.lastIndexOf("@");
+	assert.notEqual(separator, -1, `invalid exact package identity: ${identity}`);
+	return {
+		name: identity.slice(0, separator),
+		version: identity.slice(separator + 1)
+	};
+}
+
+function expectedRegistryTarball(name, version) {
+	const tarballName = name.slice(name.lastIndexOf("/") + 1);
+	return `https://registry.npmjs.org/${name}/-/${tarballName}-${version}.tgz`;
+}
+
+function npmrcSettings(source) {
+	const settings = new Map();
+	for (const line of source.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const separator = trimmed.indexOf("=");
+		assert.notEqual(separator, -1, `invalid .npmrc line: ${trimmed}`);
+		const name = trimmed.slice(0, separator);
+		assert.equal(
+			settings.has(name),
+			false,
+			`duplicate .npmrc key: ${name}`
+		);
+		settings.set(name, trimmed.slice(separator + 1));
+	}
+	return settings;
+}
+
+function workflowJob(source, name) {
+	const marker = `    ${name}:\n`;
+	const start = source.indexOf(marker);
+	assert.notEqual(start, -1, `missing ${name} job`);
+	const remainder = source.slice(start + marker.length);
+	const nextJob = remainder.search(/^ {4}[\w-]+:\n/mu);
+	return nextJob === -1
+		? source.slice(start)
+		: source.slice(start, start + marker.length + nextJob);
+}
+
+function workflowJobNames(source) {
+	return [...source.matchAll(/^ {4}([\w-]+):\n/gmu)].map(
+		match => match[1]
+	);
+}
+
+test("standalone backend approvals exactly match lockfile install scripts", () => {
+	const lockPins = installScriptPins(readJson("back-end/package-lock.json"));
+	assert.deepEqual(lockPins, exactInstallScriptPins);
+	assert.equal(
+		Object.hasOwn(readJson("back-end/package.json"), "allowScripts"),
+		false
+	);
+
+	const settings = npmrcSettings(read("back-end/.npmrc"));
+	assert.deepEqual(
+		[...settings],
+		[
+			["strict-allow-scripts", "true"],
+			["allow-scripts", exactInstallScriptPins.join(",")]
+		]
+	);
+});
+
+test("root approvals exactly match every install script in its graph", () => {
+	const packageJson = readJson("package.json");
+	const rootLockfile = readJson("package-lock.json");
+	const rootPackages = installedPackagePins(rootLockfile);
+	const standalonePinsInRoot = installScriptPins(
+		readJson("back-end/package-lock.json")
+	).filter(identity => rootPackages.has(identity));
+	const expectedApprovals = [
+		...new Set([
+			...installScriptPins(rootLockfile),
+			...standalonePinsInRoot
+		])
+	].sort();
+	const expectedDenials = ["connect-mongo", "express-rate-limit"];
+	const policyEntries = Object.entries(packageJson.allowScripts);
+	const approvals = Object.entries(packageJson.allowScripts)
+		.filter(([, allowed]) => allowed === true)
+		.map(([identity]) => identity)
+		.sort();
+	const denials = Object.entries(packageJson.allowScripts)
+		.filter(([, allowed]) => allowed === false)
+		.map(([identity]) => identity)
+		.sort();
+
+	assert.equal(
+		policyEntries.every(([, allowed]) => typeof allowed === "boolean"),
+		true
+	);
+	assert.deepEqual(
+		policyEntries.map(([identity]) => identity).sort(),
+		[...expectedApprovals, ...expectedDenials].sort()
+	);
+	assert.deepEqual(approvals, expectedApprovals);
+	assert.deepEqual(denials, expectedDenials);
+	for (const { location, name, version } of installScriptOccurrences(
+		rootLockfile
+	)) {
+		const exactDecision = packageJson.allowScripts[`${name}@${version}`];
+		const nameDecision = packageJson.allowScripts[name];
+		assert.equal(
+			exactDecision === true || nameDecision === false,
+			true,
+			`install script lacks an explicit allow or deny decision: ${location}`
+		);
+	}
+	assert.deepEqual(
+		[...npmrcSettings(read(".npmrc"))],
+		[["strict-allow-scripts", "true"]]
+	);
+});
+
+test("every exact-approved root install script has trusted lock provenance", () => {
+	const packageJson = readJson("package.json");
+	const rootLockfile = readJson("package-lock.json");
+	const approvals = Object.entries(packageJson.allowScripts)
+		.filter(([, allowed]) => allowed === true)
+		.map(([identity]) => identity);
+
+	for (const identity of approvals) {
+		const { name, version } = exactPackageIdentity(identity);
+		const occurrences = Object.entries(rootLockfile.packages).filter(
+			([location, metadata]) =>
+				location.includes("node_modules/")
+				&& packageNameFromLockPath(location) === name
+				&& metadata.version === version
+		);
+
+		assert.notEqual(
+			occurrences.length,
+			0,
+			`exact approval is absent from the root lockfile: ${identity}`
+		);
+		for (const [location, metadata] of occurrences) {
+			assert.equal(
+				metadata.resolved,
+				expectedRegistryTarball(name, version),
+				`untrusted registry source for ${identity} at ${location}`
+			);
+			assert.match(
+				metadata.integrity ?? "",
+				/^sha512-[A-Za-z0-9+/]+={0,2}$/u,
+				`missing sha512 integrity for ${identity} at ${location}`
+			);
+			assert.equal(
+				Buffer.from(metadata.integrity.slice("sha512-".length), "base64")
+					.length,
+				64,
+				`invalid sha512 integrity for ${identity} at ${location}`
+			);
+		}
+	}
+});
+
+test("backend CI installs the standalone lockfile with fail-closed flags", () => {
+	const backendInstall = workflowJob(
+		read(".github/workflows/ci.yml"),
+		"backend-install"
+	);
+	const packageManager = readJson("package.json").packageManager;
+	assert.match(packageManager, /^npm@\d+\.\d+\.\d+$/u);
+	const npmVersion = packageManager.slice("npm@".length);
+	const exactPinBlock = [
+		`                  npm i -g ${packageManager}`,
+		"                  npm -v",
+		`                  test "$(npm --version)" = "${npmVersion}"`
+	].join("\n");
+	assert.equal(
+		backendInstall.includes(exactPinBlock),
+		true,
+		"backend-install must pin and assert the root packageManager version"
+	);
+	assert.match(
+		backendInstall,
+		/^ {14}run: node --test test\/standalone-backend-install-policy\.test\.mjs$/mu
+	);
+	assert.match(
+		backendInstall,
+		/^ {14}run: npm ci --include=optional --strict-allow-scripts --workspaces=false$/mu
+	);
+	assert.match(
+		backendInstall,
+		/^ {14}run: npm audit --include=optional --workspaces=false$/mu
+	);
+});
+
+test("every root npm ci job pins and asserts the packageManager version", () => {
+	const workflow = read(".github/workflows/ci.yml");
+	const packageManager = readJson("package.json").packageManager;
+	const npmVersion = packageManager.slice("npm@".length);
+	const rootInstallJobs = workflowJobNames(workflow).filter(name =>
+		/^ {14}run: npm ci$/mu.test(workflowJob(workflow, name))
+	);
+
+	assert.notEqual(rootInstallJobs.length, 0, "missing root npm ci jobs");
+	for (const name of rootInstallJobs) {
+		const job = workflowJob(workflow, name);
+		assert.match(
+			job,
+			new RegExp(`^ {18}npm i -g ${packageManager}$`, "mu"),
+			`${name} must pin the root packageManager version`
+		);
+		assert.match(
+			job,
+			new RegExp(
+				`^ {18}test "\\$\\(npm --version\\)" = "${npmVersion}"$`,
+				"mu"
+			),
+			`${name} must assert the root packageManager version`
+		);
+	}
+});


### PR DESCRIPTION
## Summary
- authenticate Code IDE project mutations before heavy admission and body parsing, then retain concurrency reservations through awaited terminal persistence
- make root and standalone backend install-script policy fail closed with exact lock-derived approvals and trusted registry integrity
- pin and assert npm 12.0.1 across CI installs, audit optional dependencies, and carry the standalone policy safely through native release preparation
- add regression coverage for aborts, parser failures, malformed or unmatched routes, async rejection, lock provenance, CI policy, and native staging

## Validation
- strict root and standalone backend clean installs: passed
- root and backend dependency trees and audits: 0 vulnerabilities
- lint and typecheck: passed
- frontend core: 1042/1042
- course quality: 219/219
- backend: 207 passed, 1 intentional skip
- native deployment: 6/6
- static fetch policy: 5/5
- static asset audit: 246 checked, 0 missing or indeterminate
- production build and accessibility matrix: passed
- Cypress: 4/4
- local Nginx unavailable; native Nginx remains the hosted CI gate
- independent diff review: no actionable findings